### PR TITLE
fix: adiciona placeholder automaticamente ao template (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,10 @@ class SuaClasse(BaseModel):
     campo2: Literal['opcao1', 'opcao2'] = Field(..., description="Descrição do campo 2")
 
 # Defina seu template de prompt
-# IMPORTANTE: Use {documento} como placeholder (ou customize com o parâmetro 'placeholder')
-TEMPLATE = """
-Instruções para o modelo de linguagem...
+TEMPLATE = "Classifique o texto conforme as categorias definidas."
 
-Texto a ser analisado:
-{documento}
-"""
-
-# Carregue seus dados
+# Carregue seus dados (a coluna de texto deve se chamar 'texto' por padrão)
 df = pd.read_excel('seu_arquivo.xlsx')
-
-# IMPORTANTE: Sua coluna de texto deve se chamar 'texto' por padrão
-# ou use text_column='nome_da_coluna' para especificar outra coluna
 
 # Processe os dados (usa LangChain por padrão)
 df_resultado = dataframeit(df, SuaClasse, TEMPLATE)
@@ -110,51 +101,27 @@ df_resultado = dataframeit(
 
 ## Como Funciona o Template
 
-O template define as instruções para o LLM analisar cada texto. Use `{documento}` (ou um placeholder customizado) para indicar onde o texto será inserido.
+O template define as instruções para o LLM analisar cada texto. Basta escrever suas instruções:
 
-### Placeholder do Texto
+```python
+TEMPLATE = "Classifique o sentimento do texto."
+```
 
-Por padrão, use `{documento}` para indicar onde o texto de cada linha será inserido:
+O texto de cada linha do DataFrame será adicionado automaticamente ao final do prompt.
+
+### Controlando a Posição do Texto (Opcional)
+
+Se preferir controlar onde o texto aparece no prompt, use `{texto}`:
 
 ```python
 TEMPLATE = """
 Você é um analista especializado.
-Analise o documento a seguir e extraia as informações solicitadas.
 
 Documento:
-{documento}
+{texto}
+
+Extraia as informações solicitadas do documento acima.
 """
-```
-
-**Nota:** Se você não incluir o placeholder no template, ele será adicionado automaticamente ao final. Isso permite templates simples como:
-
-```python
-# Template simples - o placeholder será adicionado automaticamente
-TEMPLATE = "Classifique o sentimento do texto a seguir."
-
-# Equivale a:
-# "Classifique o sentimento do texto a seguir.
-#
-# Texto a analisar:
-# {documento}"
-```
-
-### Customizando o Placeholder
-
-Se preferir usar outro nome de placeholder:
-
-```python
-TEMPLATE = """
-Analise o seguinte review:
-{review}
-"""
-
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    placeholder='review'  # Customiza o placeholder
-)
 ```
 
 ## Parâmetros
@@ -162,13 +129,12 @@ df_resultado = dataframeit(
 ### Parâmetros Gerais
 - **`df`**: DataFrame pandas ou polars contendo os textos
 - **`questions`**: Modelo Pydantic definindo a estrutura dos dados a extrair
-- **`prompt`**: Template do prompt com placeholder para o texto
+- **`prompt`**: Template do prompt (use `{texto}` para controlar onde o texto aparece)
 - **`text_column='texto'`**: Nome da coluna que contém os textos a serem analisados
 
 ### Parâmetros de Processamento
 - **`resume=True`**: Continua processamento de onde parou (útil para grandes datasets)
 - **`status_column=None`**: Nome customizado para coluna de status (padrão: `_dataframeit_status`)
-- **`placeholder='documento'`**: Nome do placeholder no template que será substituído pelo texto
 
 ### Parâmetros de Resiliência
 - **`max_retries=3`**: Número máximo de tentativas em caso de erro

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -18,7 +18,6 @@ def dataframeit(
     provider='google_genai',
     status_column=None,
     text_column: str = 'texto',
-    placeholder: str = 'documento',
     use_openai=False,
     openai_client=None,
     reasoning_effort='minimal',
@@ -35,14 +34,13 @@ def dataframeit(
     Args:
         df: DataFrame pandas ou polars contendo textos.
         questions: Modelo Pydantic definindo estrutura a extrair.
-        prompt: Template do prompt com placeholder para texto.
+        prompt: Template do prompt (use {texto} para indicar onde inserir o texto).
         perguntas: (Deprecated) Use 'questions'.
         resume: Se True, continua de onde parou.
         model: Nome do modelo LLM.
         provider: Provider do LangChain ('google_genai', etc).
         status_column: Coluna para rastrear progresso.
         text_column: Nome da coluna com textos.
-        placeholder: Nome do placeholder no prompt.
         use_openai: Se True, usa OpenAI em vez de LangChain.
         openai_client: Cliente OpenAI customizado.
         reasoning_effort: Esforço de raciocínio OpenAI.
@@ -70,10 +68,9 @@ def dataframeit(
     if prompt is None:
         raise ValueError("Parâmetro 'prompt' é obrigatório")
 
-    # Se o placeholder não estiver no template, adiciona automaticamente ao final
-    placeholder_tag = f"{{{placeholder}}}"
-    if placeholder_tag not in prompt:
-        prompt = prompt.rstrip() + f"\n\nTexto a analisar:\n{placeholder_tag}"
+    # Se {texto} não estiver no template, adiciona automaticamente ao final
+    if '{texto}' not in prompt:
+        prompt = prompt.rstrip() + "\n\nTexto a analisar:\n{texto}"
 
     # Converter para pandas se necessário
     df_pandas, was_polars = to_pandas(df)
@@ -116,7 +113,6 @@ def dataframeit(
         max_retries=max_retries,
         base_delay=base_delay,
         max_delay=max_delay,
-        placeholder=placeholder,
         rate_limit_delay=rate_limit_delay,
     )
 


### PR DESCRIPTION
## Summary

- Simplifica o uso do template: basta escrever as instruções, o texto é adicionado automaticamente
- Usa `{texto}` como placeholder fixo (sem customização)
- Remove parâmetro `placeholder` da API
- Atualiza README com documentação simplificada

## Exemplo de uso

```python
# Simples - texto adicionado automaticamente ao final
TEMPLATE = "Classifique o sentimento."

# Ou controle a posição com {texto}
TEMPLATE = "Analise:\n{texto}\n\nResponda conforme solicitado."

Fixes #38 