### PR TITLE
docs: add MkDocs documentation with Material theme and i18n

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material mkdocs-static-i18n
+
+      - name: Build documentation
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ htmlcov/
 
 # Project specific
 *.log
+site/

--- a/README.md
+++ b/README.md
@@ -1,601 +1,85 @@
 # DataFrameIt
 
-Uma biblioteca Python para enriquecer DataFrames com análises de texto usando Modelos de Linguagem (LLMs).
+[![PyPI version](https://badge.fury.io/py/dataframeit.svg)](https://badge.fury.io/py/dataframeit)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Descrição
+**Enriqueça DataFrames com LLMs de forma simples e estruturada.**
 
-DataFrameIt é uma ferramenta que permite processar textos contidos em um DataFrame e extrair informações estruturadas usando LLMs. A biblioteca usa **LangChain** para suportar múltiplos provedores de modelos (Gemini, OpenAI, Anthropic, etc.). Pandas é utilizado para manipulação de dados, com suporte para Polars via conversão interna.
+DataFrameIt processa textos em DataFrames usando Modelos de Linguagem (LLMs) e extrai informações estruturadas definidas por modelos Pydantic.
 
-## Funcionalidades
-
-- Processar cada linha de um DataFrame que contenha textos
-- Utilizar prompt templates para análise específica de domínio
-- Extrair informações estruturadas usando modelos Pydantic
-- **Múltiplos providers**: Gemini, OpenAI, Anthropic, Cohere, Mistral, etc. via LangChain
-- **Múltiplos tipos de dados**: DataFrames, Series, listas e dicionários
-- Suporte para Polars e Pandas
-- Processamento incremental com resumo automático
-- **Processamento paralelo** com auto-redução de workers em rate limits
-- **Retry automático** com backoff exponencial para resiliência
-- **Rate limiting** configurável para respeitar limites de APIs
-- **Rastreamento de erros** com coluna automática `_error_details`
-- **Tracking de tokens** e métricas de throughput (RPM, TPM)
+**[Documentação Completa](https://bdcdo.github.io/dataframeit)** | **[Referência para LLMs](https://bdcdo.github.io/dataframeit/reference/llm-reference/)**
 
 ## Instalação
 
 ```bash
-# Com Google Gemini (provider padrão, recomendado)
-pip install dataframeit[google]
-
-# Ou com outros providers
-pip install dataframeit[openai]     # GPT-4, GPT-4o
-pip install dataframeit[anthropic]  # Claude
-
-# Com Polars (opcional)
-pip install dataframeit[google,polars]
-
-# Tudo incluído
-pip install dataframeit[all]
+pip install dataframeit[google]  # Google Gemini (recomendado)
+pip install dataframeit[openai]  # OpenAI
+pip install dataframeit[anthropic]  # Anthropic Claude
 ```
 
-## Uso Básico
+Configure sua API key:
 
-### Com LangChain (comportamento padrão)
+```bash
+export GOOGLE_API_KEY="sua-chave"  # ou OPENAI_API_KEY, ANTHROPIC_API_KEY
+```
+
+## Exemplo Rápido
 
 ```python
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Literal
 import pandas as pd
 from dataframeit import dataframeit
 
-# Defina um modelo Pydantic para estruturar as respostas
-class SuaClasse(BaseModel):
-    campo1: str = Field(..., description="Descrição do campo 1")
-    campo2: Literal['opcao1', 'opcao2'] = Field(..., description="Descrição do campo 2")
+# 1. Defina o que extrair
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+    confianca: Literal['alta', 'media', 'baixa']
 
-# Defina seu template de prompt
-TEMPLATE = "Classifique o texto conforme as categorias definidas."
+# 2. Seus dados
+df = pd.DataFrame({
+    'texto': [
+        'Produto excelente! Superou expectativas.',
+        'Péssimo atendimento, nunca mais compro.',
+        'Entrega ok, produto mediano.'
+    ]
+})
 
-# Carregue seus dados (a coluna de texto deve se chamar 'texto' por padrão)
-df = pd.read_excel('seu_arquivo.xlsx')
-
-# Processe os dados (usa LangChain por padrão)
-df_resultado = dataframeit(df, SuaClasse, TEMPLATE)
-
-# Salve o resultado
-df_resultado.to_excel('resultado.xlsx', index=False)
+# 3. Processe!
+resultado = dataframeit(df, Sentimento, "Analise o sentimento do texto.")
+print(resultado)
 ```
 
-### Com OpenAI (via LangChain)
+**Saída:**
 
-```python
-from dataframeit import dataframeit
+| texto | sentimento | confianca |
+|-------|------------|-----------|
+| Produto excelente! ... | positivo | alta |
+| Péssimo atendimento... | negativo | alta |
+| Entrega ok... | neutro | media |
 
-# Uso básico com OpenAI
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    provider='openai',
-    model='gpt-4o-mini'
-)
+## Funcionalidades
 
-# Com parâmetros extras (model_kwargs)
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    provider='openai',
-    model='gpt-4o-mini',
-    model_kwargs={
-        'temperature': 0.5,          # Controle de criatividade
-        'reasoning_effort': 'medium', # Para modelos com reasoning (o1, o3)
-    }
-)
-```
+- **Múltiplos providers**: Google Gemini, OpenAI, Anthropic, Cohere, Mistral via LangChain
+- **Múltiplos tipos de entrada**: DataFrame, Series, list, dict
+- **Saída estruturada**: Validação automática com Pydantic
+- **Resiliência**: Retry automático com backoff exponencial
+- **Performance**: Processamento paralelo, rate limiting configurável
+- **Busca web**: Integração com Tavily para enriquecer dados
+- **Tracking**: Monitoramento de tokens e métricas de throughput
 
-### Parâmetros Extras (model_kwargs)
+## Documentação
 
-O parâmetro `model_kwargs` permite passar configurações específicas do provider para o LangChain:
+- [Início Rápido](https://bdcdo.github.io/dataframeit/getting-started/quickstart/)
+- [Guias](https://bdcdo.github.io/dataframeit/guides/basic-usage/)
+- [Referência da API](https://bdcdo.github.io/dataframeit/reference/api/)
+- [Referência para LLMs](https://bdcdo.github.io/dataframeit/reference/llm-reference/) - Página compacta otimizada para assistentes de código
 
-```python
-# OpenAI com reasoning (modelos o1, o3-mini)
-df_resultado = dataframeit(
-    df, Model, TEMPLATE,
-    provider='openai',
-    model='o3-mini',
-    model_kwargs={
-        'reasoning_effort': 'high',  # 'low', 'medium', 'high'
-    }
-)
+## Exemplos
 
-# Google Gemini com configurações extras
-df_resultado = dataframeit(
-    df, Model, TEMPLATE,
-    provider='google_genai',
-    model='gemini-3.0-flash',
-    model_kwargs={
-        'temperature': 0.2,
-        'top_p': 0.9,
-    }
-)
-
-# Anthropic Claude com configurações extras
-df_resultado = dataframeit(
-    df, Model, TEMPLATE,
-    provider='anthropic',
-    model='claude-3-5-sonnet-20241022',
-    model_kwargs={
-        'max_tokens': 4096,
-    }
-)
-```
-
-> **Nota**: Os parâmetros disponíveis em `model_kwargs` dependem do provider. Consulte a documentação do LangChain para cada provider.
-
-## Tipos de Dados Suportados
-
-Além de DataFrames, o DataFrameIt aceita outros tipos de dados para facilitar o uso em diferentes cenários.
-
-### Com Lista de Textos
-
-```python
-from dataframeit import dataframeit
-
-textos = [
-    "Ótimo produto! Chegou rápido.",
-    "Péssimo atendimento.",
-    "Produto ok, nada de especial."
-]
-
-# Não precisa especificar text_column para listas
-resultado = dataframeit(textos, SuaClasse, TEMPLATE)
-
-# Retorna DataFrame com índice numérico + colunas extraídas
-#   | sentimento | confianca
-# 0 | positivo   | alta
-# 1 | negativo   | alta
-# 2 | neutro     | media
-```
-
-### Com Dicionário
-
-```python
-documentos = {
-    'doc_001': 'Texto do primeiro documento...',
-    'doc_002': 'Texto do segundo documento...',
-    'doc_003': 'Texto do terceiro documento...',
-}
-
-resultado = dataframeit(documentos, SuaClasse, TEMPLATE)
-
-# Retorna DataFrame com chaves como índice
-#         | sentimento | confianca
-# doc_001 | positivo   | alta
-# doc_002 | negativo   | media
-# doc_003 | neutro     | baixa
-```
-
-### Com pandas.Series
-
-```python
-import pandas as pd
-
-series = pd.Series(
-    ['Texto A', 'Texto B', 'Texto C'],
-    index=['review_1', 'review_2', 'review_3'],
-    name='avaliacoes'
-)
-
-resultado = dataframeit(series, SuaClasse, TEMPLATE)
-
-# Retorna DataFrame preservando o índice original
-#          | sentimento | confianca
-# review_1 | positivo   | alta
-# review_2 | negativo   | media
-# review_3 | neutro     | baixa
-```
-
-### Resumo dos Tipos
-
-| Tipo de Entrada | `text_column` | Tipo de Retorno |
-|-----------------|---------------|-----------------|
-| `pd.DataFrame` | Obrigatório (padrão: `'texto'`) | `pd.DataFrame` com colunas originais + extraídas |
-| `pl.DataFrame` | Obrigatório (padrão: `'texto'`) | `pl.DataFrame` com colunas originais + extraídas |
-| `list` | Automático | `pd.DataFrame` (índice numérico) |
-| `dict` | Automático | `pd.DataFrame` (chaves como índice) |
-| `pd.Series` | Automático | `pd.DataFrame` (índice preservado) |
-| `pl.Series` | Automático | `pl.DataFrame` |
-
-## Como Funciona o Template
-
-O template define as instruções para o LLM analisar cada texto. Basta escrever suas instruções:
-
-```python
-TEMPLATE = "Classifique o sentimento do texto."
-```
-
-O texto de cada linha do DataFrame será adicionado automaticamente ao final do prompt.
-
-### Controlando a Posição do Texto (Opcional)
-
-Se preferir controlar onde o texto aparece no prompt, use `{texto}`:
-
-```python
-TEMPLATE = """
-Você é um analista especializado.
-
-Documento:
-{texto}
-
-Extraia as informações solicitadas do documento acima.
-"""
-```
-
-## Parâmetros
-
-### Parâmetros Gerais
-- **`data`**: Dados contendo os textos. Aceita:
-  - `pandas.DataFrame` ou `polars.DataFrame`
-  - `pandas.Series` ou `polars.Series`
-  - `list` (lista de strings)
-  - `dict` (dicionário onde valores são os textos)
-- **`questions`**: Modelo Pydantic definindo a estrutura dos dados a extrair
-- **`prompt`**: Template do prompt (use `{texto}` para controlar onde o texto aparece)
-- **`text_column`**: Nome da coluna com os textos (obrigatório para DataFrames, padrão: `'texto'`; automático para Series/list/dict)
-
-### Parâmetros de Processamento
-- **`resume=True`**: Continua processamento de onde parou (útil para grandes datasets)
-- **`status_column=None`**: Nome customizado para coluna de status (padrão: `_dataframeit_status`)
-
-### Parâmetros de Resiliência
-- **`max_retries=3`**: Número máximo de tentativas em caso de erro
-- **`base_delay=1.0`**: Delay inicial em segundos para retry (cresce exponencialmente)
-- **`max_delay=30.0`**: Delay máximo em segundos entre tentativas
-- **`rate_limit_delay=0.0`**: Delay em segundos entre requisições para evitar rate limits
-
-### Parâmetros de Paralelismo
-- **`parallel_requests=1`**: Número de requisições paralelas (1 = sequencial)
-  - Ao detectar erro 429 (rate limit), reduz automaticamente pela metade
-  - Métricas de throughput (RPM, TPM) são exibidas automaticamente
-
-### Parâmetros de Monitoramento
-- **`track_tokens=True`**: Rastreia uso de tokens e exibe estatísticas ao final (requer LangChain 1.0+)
-
-### Parâmetros do Modelo
-- **`model='gemini-3.0-flash'`**: Modelo a ser usado
-- **`provider='google_genai'`**: Provider do LangChain ('google_genai', 'openai', 'anthropic', etc.)
-- **`api_key=None`**: Chave API específica (opcional, usa variáveis de ambiente se None)
-- **`model_kwargs=None`**: Parâmetros extras para o modelo (ex: `temperature`, `reasoning_effort`)
-
-## Tratamento de Erros
-
-O DataFrameIt possui um sistema robusto de tratamento de erros:
-
-### Colunas de Status
-- **`_dataframeit_status`**: Coluna automática com status de cada linha
-  - `'processed'`: Linha processada com sucesso
-  - `'error'`: Linha falhou após todas as tentativas
-  - `None/NaN`: Linha ainda não processada
-
-- **`_error_details`**: Coluna automática com detalhes de erros
-  - Contém mensagem de erro quando status é `'error'`
-  - `None/NaN` quando processamento foi bem-sucedido
-
-### Exemplo: Verificando Erros
-
-```python
-df_resultado = dataframeit(df, SuaClasse, TEMPLATE)
-
-# Verificar linhas com erro
-linhas_com_erro = df_resultado[df_resultado['_dataframeit_status'] == 'error']
-print(f"Total de erros: {len(linhas_com_erro)}")
-
-# Ver detalhes dos erros
-for idx, row in linhas_com_erro.iterrows():
-    print(f"Linha {idx}: {row['_error_details']}")
-
-# Salvar apenas linhas processadas com sucesso
-df_sucesso = df_resultado[df_resultado['_dataframeit_status'] == 'processed']
-df_sucesso.to_excel('resultado_limpo.xlsx', index=False)
-```
-
-### Sistema de Retry
-
-O DataFrameIt tenta automaticamente processar linhas com falha usando backoff exponencial:
-
-```python
-# Configurando retry mais agressivo
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    max_retries=5,        # Tentar até 5 vezes
-    base_delay=2.0,       # Começar com 2 segundos de espera
-    max_delay=60.0        # Esperar no máximo 60 segundos entre tentativas
-)
-```
-
-A espera entre tentativas cresce exponencialmente: 2s → 4s → 8s → 16s → 32s (limitado a 60s).
-
-## Rate Limiting
-
-O DataFrameIt oferece controle proativo de rate limiting para evitar atingir limites de requisições das APIs.
-
-### Por que usar Rate Limiting?
-
-- **Prevenir erros**: Evita atingir limites de requisições antes de acontecer
-- **Eficiência**: Reduz desperdício de retries em datasets grandes
-- **Economia**: Algumas APIs cobram por tentativa, mesmo as que falham
-- **Complementar ao Retry**: O rate limiting PREVINE erros, o retry TRATA erros
-
-### Quando usar?
-
-Use `rate_limit_delay` quando:
-- Processar datasets grandes (> 100 linhas)
-- Conhecer os limites da API (ex: 60 req/min)
-- Fazer processamento em lote
-- Quiser economizar retries para erros reais
-
-### Exemplos Práticos
-
-```python
-# Google Gemini: 60 requisições por minuto (free tier)
-# Solução: 1 requisição por segundo = 60 req/min
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    rate_limit_delay=1.0
-)
-
-# OpenAI GPT-4: limite de 500 req/min (tier 1)
-# Solução: ~0.15 segundos entre requisições = ~400 req/min (margem de segurança)
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    provider='openai',
-    model='gpt-4o-mini',
-    rate_limit_delay=0.15
-)
-
-# Anthropic Claude: limite de 50 req/min (free tier)
-# Solução: 1.2 segundos entre requisições = 50 req/min
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    provider='anthropic',
-    model='claude-3-5-sonnet-20241022',
-    rate_limit_delay=1.2
-)
-
-# Dataset pequeno: não precisa de rate limiting
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    rate_limit_delay=0.0  # Padrão: sem delay
-)
-```
-
-### Como calcular o delay ideal?
-
-```
-rate_limit_delay = 60 / limite_de_requisições_por_minuto
-
-Exemplos:
-- 60 req/min  → delay = 60/60  = 1.0 segundo
-- 500 req/min → delay = 60/500 = 0.12 segundos
-- 50 req/min  → delay = 60/50  = 1.2 segundos
-```
-
-### Rate Limiting + Retry: Dupla Proteção
-
-```python
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    # Rate limiting proativo
-    rate_limit_delay=1.0,      # Previne rate limits
-
-    # Retry reativo
-    max_retries=3,             # Trata erros inesperados
-    base_delay=2.0,
-    max_delay=30.0
-)
-```
-
-## Processamento Paralelo
-
-O DataFrameIt suporta processamento paralelo para acelerar o processamento de grandes datasets.
-
-### Parâmetro `parallel_requests`
-
-```python
-# Processar com 5 requisições paralelas
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    parallel_requests=5     # Número de workers paralelos
-)
-```
-
-### Métricas de Throughput
-
-O DataFrameIt exibe automaticamente métricas detalhadas ao final do processamento:
-
-```
-============================================================
-ESTATISTICAS DE USO
-============================================================
-Modelo: gemini-2.5-flash
-Total de tokens: 15,432
-  - Input:  12,345 tokens
-  - Output: 3,087 tokens
-------------------------------------------------------------
-METRICAS DE THROUGHPUT
-------------------------------------------------------------
-Tempo total: 45.2s
-Workers paralelos: 5
-Requisicoes: 100
-  - RPM (req/min): 132.7
-  - TPM (tokens/min): 20,478
-============================================================
-```
-
-Use essas métricas para calibrar o número ideal de `parallel_requests` para sua conta/tier.
-
-### Auto-redução de Workers em Rate Limits
-
-Quando um erro de rate limit (429) é detectado, o DataFrameIt **reduz automaticamente** o número de workers pela metade:
-
-```python
-# Começa com 10 workers
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    parallel_requests=10
-)
-
-# Se detectar rate limit:
-# - Workers são reduzidos: 10 → 5 → 2 → 1
-# - Você verá um aviso: "Rate limit detectado! Reduzindo workers de 10 para 5."
-# - Ao final, as estatísticas mostram a redução
-```
-
-**Importante**: Os workers são apenas **reduzidos**, nunca aumentados automaticamente. Isso evita custos inesperados para o usuário.
-
-### Combinando com Rate Limit Delay
-
-Para máxima estabilidade, combine `parallel_requests` com `rate_limit_delay`:
-
-```python
-# 5 workers paralelos, com 0.5s entre cada requisição por worker
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    parallel_requests=5,
-    rate_limit_delay=0.5     # Delay adicional por requisição
-)
-```
-
-### Dicas de Uso
-
-| Cenário | Configuração Recomendada |
-|---------|-------------------------|
-| Dataset pequeno (< 50 linhas) | `parallel_requests=1` (padrão) |
-| Dataset médio (50-500 linhas) | `parallel_requests=3` a `5` |
-| Dataset grande (> 500 linhas) | `parallel_requests=5` a `10` |
-| API com limite baixo | `parallel_requests=2` + `rate_limit_delay=1.0` |
-| Tier pago com limites altos | `parallel_requests=10` ou mais |
-
-## Processamento Incremental
-
-Para grandes datasets, use `resume=True` para continuar de onde parou:
-
-```python
-# Primeira execução (processa 100 linhas e falha)
-df_resultado = dataframeit(df, SuaClasse, TEMPLATE, resume=True)
-df_resultado.to_excel('resultado_parcial.xlsx', index=False)
-
-# Segunda execução (continua das linhas não processadas)
-df = pd.read_excel('resultado_parcial.xlsx')
-df_resultado = dataframeit(df, SuaClasse, TEMPLATE, resume=True)
-df_resultado.to_excel('resultado_completo.xlsx', index=False)
-```
-
-## Tracking de Tokens e Custos
-
-O DataFrameIt pode rastrear automaticamente o uso de tokens para monitoramento de custos (disponível com LangChain 1.0+).
-
-### Como Usar
-
-```python
-# Habilitar tracking de tokens
-df_resultado = dataframeit(
-    df,
-    SuaClasse,
-    TEMPLATE,
-    track_tokens=True  # Habilita tracking de tokens
-)
-
-# Ao final do processamento, exibe estatísticas:
-# ============================================================
-# 📊 ESTATÍSTICAS DE USO DE TOKENS
-# ============================================================
-# Modelo: gemini-3.0-flash
-# Total de tokens: 15,432
-#   • Input:  12,345 tokens
-#   • Output: 3,087 tokens
-# ============================================================
-```
-
-### Colunas Adicionadas ao DataFrame
-
-Quando `track_tokens=True`, o DataFrame incluirá automaticamente:
-
-- **`_input_tokens`**: Tokens de entrada (prompt) por linha
-- **`_output_tokens`**: Tokens de saída (resposta) por linha
-- **`_total_tokens`**: Total de tokens por linha
-
-### Analisando Custos
-
-```python
-# Processar com tracking
-df_resultado = dataframeit(df, SuaClasse, TEMPLATE, track_tokens=True)
-
-# Analisar uso por linha
-print(f"Linha mais cara: {df_resultado['_total_tokens'].max()} tokens")
-print(f"Média de tokens: {df_resultado['_total_tokens'].mean():.1f} tokens")
-
-# Calcular custo estimado (exemplo: Gemini 3.0 Flash)
-# Input: $0.075 por 1M tokens, Output: $0.30 por 1M tokens
-custo_input = df_resultado['_input_tokens'].sum() * 0.075 / 1_000_000
-custo_output = df_resultado['_output_tokens'].sum() * 0.30 / 1_000_000
-custo_total = custo_input + custo_output
-print(f"Custo estimado: ${custo_total:.4f}")
-```
-
-### Compatibilidade
-
-- ✅ **LangChain 1.0+** com `usage_metadata` (Gemini, Claude, GPT via LangChain)
-- ⚠️ Versões anteriores do LangChain não incluem `usage_metadata`
-
-## Exemplo Completo
-
-Veja o diretório `example/` para um caso de uso completo com análise de decisões judiciais, incluindo:
-- Modelo Pydantic complexo com classes aninhadas
-- Template detalhado com instruções específicas de domínio
-- Uso de campos opcionais e tipos Literal
-- Processamento de listas e tuplas
-
-## Configuração de Variáveis de Ambiente
-
-### Para OpenAI
-```bash
-export OPENAI_API_KEY="sua-chave-openai"
-```
-
-### Para Google Gemini (LangChain)
-```bash
-export GOOGLE_API_KEY="sua-chave-google"
-```
-
-### Para Anthropic Claude (LangChain)
-```bash
-export ANTHROPIC_API_KEY="sua-chave-anthropic"
-```
-
-## Contribuições
-
-Contribuições são bem-vindas! Este é um projeto em desenvolvimento inicial.
+Veja a pasta [`example/`](example/) para notebooks Jupyter com casos de uso completos.
 
 ## Licença
 
-Veja o arquivo LICENSE para detalhes.
+MIT

--- a/docs/en/examples/index.md
+++ b/docs/en/examples/index.md
@@ -1,0 +1,146 @@
+# Examples
+
+Practical examples in Jupyter Notebooks to learn DataFrameIt.
+
+## Available Notebooks
+
+Examples are organized from basic to advanced. We recommend following in order.
+
+### 1. Basic
+**[01_basic.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/01_basic.ipynb)**
+
+Introduction to DataFrameIt with sentiment analysis.
+
+- Create simple Pydantic model
+- Process basic DataFrame
+- Understand the output
+
+```python
+from pydantic import BaseModel
+from typing import Literal
+
+class Sentiment(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+```
+
+---
+
+### 2. Error Handling
+**[02_error_handling.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/02_error_handling.ipynb)**
+
+How to handle errors and configure retry.
+
+- Configure `max_retries`, `base_delay`, `max_delay`
+- Check `_dataframeit_status` column
+- Analyze `_error_details`
+
+---
+
+### 3. Incremental Processing
+**[03_resume.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/03_resume.ipynb)**
+
+Continue processing from where it stopped.
+
+- Use `resume=True`
+- Save and load partial results
+- Reprocess only error rows
+
+---
+
+### 4. Custom Placeholder
+**[04_custom_placeholder.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/04_custom_placeholder.ipynb)**
+
+Control where text appears in the prompt.
+
+- Use `{texto}` in template
+- Create complex multi-part prompts
+
+---
+
+### 5. Advanced Case: Legal Analysis
+**[05_advanced_legal.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/05_advanced_legal.ipynb)**
+
+Real example with complex Pydantic model.
+
+- Nested models
+- Optional fields
+- Lists of objects
+- Multiple entity extraction
+
+```python
+class Party(BaseModel):
+    name: str
+    type: Literal['plaintiff', 'defendant']
+
+class Decision(BaseModel):
+    parties: List[Party]
+    outcome: Literal['granted', 'denied']
+```
+
+---
+
+### 6. Polars
+**[06_polars.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/06_polars.ipynb)**
+
+Use DataFrameIt with Polars instead of Pandas.
+
+- Input with `polars.DataFrame`
+- Output preserves Polars type
+
+---
+
+### 7. Multiple Data Types
+**[07_multiple_data_types.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/07_multiple_data_types.ipynb)**
+
+Process different input types.
+
+- Lists
+- Dictionaries
+- Series
+
+---
+
+### 8. Rate Limiting
+**[08_rate_limiting.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/08_rate_limiting.ipynb)**
+
+Control request rate.
+
+- Configure `rate_limit_delay`
+- Use `parallel_requests`
+- Combine for maximum efficiency
+
+---
+
+## Running the Examples
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/bdcdo/dataframeit.git
+cd dataframeit
+```
+
+### 2. Install Dependencies
+
+```bash
+pip install dataframeit[google]
+pip install jupyter
+```
+
+### 3. Configure your API Key
+
+```bash
+export GOOGLE_API_KEY="your-key"
+```
+
+### 4. Run Jupyter
+
+```bash
+jupyter notebook example/
+```
+
+---
+
+## Contributing Examples
+
+If you created an interesting example, consider contributing! Open an issue or pull request on [GitHub](https://github.com/bdcdo/dataframeit).

--- a/docs/en/getting-started/concepts.md
+++ b/docs/en/getting-started/concepts.md
@@ -1,0 +1,130 @@
+# Concepts
+
+Understand the fundamental concepts of DataFrameIt.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        dataframeit()                         │
+├─────────────────────────────────────────────────────────────┤
+│  Input             │  Processing         │  Output          │
+│  ─────             │  ──────────         │  ──────          │
+│  • DataFrame       │  • For each row:    │  • DataFrame     │
+│  • Series          │    1. Build prompt  │    with extracted│
+│  • List            │    2. Call LLM      │    columns       │
+│  • Dict            │    3. Validate resp.│                  │
+│                    │    4. Retry on error│                  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     LangChain + Provider                     │
+├─────────────────────────────────────────────────────────────┤
+│  Google Gemini │ OpenAI │ Anthropic │ Cohere │ Mistral      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Main Components
+
+### 1. Pydantic Model
+
+The Pydantic model defines **what** you want to extract. Each field becomes a column in the output DataFrame.
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    # Required field with fixed values
+    category: Literal['A', 'B', 'C'] = Field(
+        description="Item category"
+    )
+
+    # Required field with free text
+    summary: str = Field(
+        description="Summary in one sentence"
+    )
+
+    # Optional field
+    notes: Optional[str] = Field(
+        default=None,
+        description="Additional notes, if any"
+    )
+```
+
+!!! info "Why Pydantic?"
+    - **Automatic validation**: The LLM is forced to return data in the correct format
+    - **Documentation**: Field descriptions help the LLM understand what to extract
+    - **Type safety**: Type errors are caught automatically
+
+### 2. Prompt Template
+
+The prompt defines **how** the LLM should process each text.
+
+```python
+# Simple - text is automatically added at the end
+PROMPT = "Classify the sentiment of the text."
+
+# With placeholder - control where text appears
+PROMPT = """
+You are a specialized analyst.
+
+Document:
+{texto}
+
+Extract the requested information from the document above.
+"""
+```
+
+### 3. Providers via LangChain
+
+DataFrameIt uses LangChain to abstract different LLM providers:
+
+| Provider | Popular Models | Environment Variable |
+|----------|----------------|---------------------|
+| `google_genai` | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
+| `openai` | gpt-4o, gpt-4o-mini, o1, o3-mini | `OPENAI_API_KEY` |
+| `anthropic` | claude-3-5-sonnet, claude-3-opus | `ANTHROPIC_API_KEY` |
+
+## Processing Flow
+
+```
+For each DataFrame row:
+│
+├─► 1. Build prompt (template + row text)
+│
+├─► 2. Send to LLM via LangChain
+│
+├─► 3. Receive structured response
+│
+├─► 4. Validate with Pydantic
+│   │
+│   ├─► Success: mark as 'processed'
+│   │
+│   └─► Error: retry with exponential backoff
+│       │
+│       ├─► Success after retry: mark as 'processed'
+│       │
+│       └─► Failure after max_retries: mark as 'error'
+│
+└─► 5. Add extracted fields to DataFrame
+```
+
+## Automatic Columns
+
+DataFrameIt automatically adds control columns:
+
+| Column | Description |
+|--------|-------------|
+| `_dataframeit_status` | Status: `'processed'`, `'error'`, or `None` |
+| `_error_details` | Error details (when status is `'error'`) |
+| `_input_tokens` | Input tokens (with `track_tokens=True`) |
+| `_output_tokens` | Output tokens (with `track_tokens=True`) |
+| `_total_tokens` | Total tokens (with `track_tokens=True`) |
+
+## Next Steps
+
+- [Basic Usage](../guides/basic-usage.md): Practical examples
+- [Error Handling](../guides/error-handling.md): Configure retry and fallbacks
+- [Performance](../guides/performance.md): Parallelism and rate limiting

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -1,0 +1,82 @@
+# Installation
+
+## Basic Installation
+
+DataFrameIt uses [LangChain](https://langchain.com/) to support multiple LLM providers. Choose the provider you want to use:
+
+=== "Google Gemini (Recommended)"
+
+    ```bash
+    pip install dataframeit[google]
+    ```
+
+    Models: `gemini-2.0-flash`, `gemini-1.5-pro`, `gemini-1.5-flash`
+
+=== "OpenAI"
+
+    ```bash
+    pip install dataframeit[openai]
+    ```
+
+    Models: `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `o1`, `o3-mini`
+
+=== "Anthropic"
+
+    ```bash
+    pip install dataframeit[anthropic]
+    ```
+
+    Models: `claude-3-5-sonnet-20241022`, `claude-3-opus-20240229`
+
+=== "All Providers"
+
+    ```bash
+    pip install dataframeit[all]
+    ```
+
+## With Polars (Optional)
+
+If you use Polars instead of Pandas:
+
+```bash
+pip install dataframeit[google,polars]
+```
+
+## API Keys Configuration
+
+Set the environment variable for your provider:
+
+=== "Google Gemini"
+
+    ```bash
+    export GOOGLE_API_KEY="your-google-key"
+    ```
+
+    Get your key at: [Google AI Studio](https://aistudio.google.com/apikey)
+
+=== "OpenAI"
+
+    ```bash
+    export OPENAI_API_KEY="your-openai-key"
+    ```
+
+    Get your key at: [OpenAI Platform](https://platform.openai.com/api-keys)
+
+=== "Anthropic"
+
+    ```bash
+    export ANTHROPIC_API_KEY="your-anthropic-key"
+    ```
+
+    Get your key at: [Anthropic Console](https://console.anthropic.com/)
+
+## Verifying Installation
+
+```python
+from dataframeit import dataframeit
+print("DataFrameIt installed successfully!")
+```
+
+## Next Step
+
+Now that you've installed DataFrameIt, see the [Quickstart](quickstart.md) to create your first project.

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart
+
+This guide shows you how to use DataFrameIt in 5 minutes.
+
+## Step 1: Define your Pydantic Model
+
+The Pydantic model defines the structure of data you want to extract:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class Sentiment(BaseModel):
+    """Sentiment analysis of a text."""
+    sentiment: Literal['positive', 'negative', 'neutral'] = Field(
+        description="Overall sentiment of the text"
+    )
+    confidence: Literal['high', 'medium', 'low'] = Field(
+        description="Confidence level in the classification"
+    )
+```
+
+!!! tip "Tip"
+    Use `Literal` for fields with fixed values. This ensures the LLM only returns valid values.
+
+## Step 2: Prepare your Data
+
+DataFrameIt accepts various input types:
+
+=== "DataFrame"
+
+    ```python
+    import pandas as pd
+
+    df = pd.DataFrame({
+        'text': [
+            'Excellent product! Exceeded expectations.',
+            'Terrible service, never buying again.',
+            'Delivery ok, average product.'
+        ]
+    })
+    ```
+
+=== "List"
+
+    ```python
+    texts = [
+        'Excellent product! Exceeded expectations.',
+        'Terrible service, never buying again.',
+        'Delivery ok, average product.'
+    ]
+    ```
+
+=== "Dictionary"
+
+    ```python
+    texts = {
+        'review_001': 'Excellent product! Exceeded expectations.',
+        'review_002': 'Terrible service, never buying again.',
+        'review_003': 'Delivery ok, average product.'
+    }
+    ```
+
+## Step 3: Process!
+
+```python
+from dataframeit import dataframeit
+
+result = dataframeit(
+    df,                                      # Your data
+    Sentiment,                               # Pydantic model
+    "Analyze the sentiment of the text.",    # Prompt
+    text_column='text'                       # Column name
+)
+
+print(result)
+```
+
+**Output:**
+
+```
+                                        text sentiment confidence
+0  Excellent product! Exceeded expectations.  positive       high
+1      Terrible service, never buying again.  negative       high
+2               Delivery ok, average product.   neutral     medium
+```
+
+## Complete Example
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Pydantic Model
+class Sentiment(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+    confidence: Literal['high', 'medium', 'low']
+
+# 2. Data
+df = pd.DataFrame({
+    'text': [
+        'Excellent product! Exceeded expectations.',
+        'Terrible service, never buying again.',
+        'Delivery ok, average product.'
+    ]
+})
+
+# 3. Process
+result = dataframeit(df, Sentiment, "Analyze the sentiment of the text.", text_column='text')
+
+# 4. Save
+result.to_excel('result.xlsx', index=False)
+```
+
+## Next Steps
+
+- [Concepts](concepts.md): Understand how DataFrameIt works
+- [Basic Usage](../guides/basic-usage.md): More practical examples
+- [Error Handling](../guides/error-handling.md): Dealing with failures

--- a/docs/en/guides/basic-usage.md
+++ b/docs/en/guides/basic-usage.md
@@ -1,0 +1,140 @@
+# Basic Usage
+
+Practical examples for common use cases.
+
+## Sentiment Analysis
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class Sentiment(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+    confidence: Literal['high', 'medium', 'low']
+
+df = pd.DataFrame({
+    'text': [
+        'Love this product!',
+        'Terrible, do not recommend.',
+        'Average, nothing special.'
+    ]
+})
+
+result = dataframeit(df, Sentiment, "Analyze the sentiment of the text.", text_column='text')
+```
+
+## Category Classification
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class Category(BaseModel):
+    category: Literal['technology', 'health', 'finance', 'education', 'other']
+    subcategory: str = Field(description="More specific subcategory")
+
+result = dataframeit(
+    df,
+    Category,
+    "Classify the text into the most appropriate category.",
+    text_column='text'
+)
+```
+
+## Entity Extraction
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+class Entities(BaseModel):
+    people: List[str] = Field(description="Names of people mentioned")
+    organizations: List[str] = Field(description="Company/organization names")
+    locations: List[str] = Field(description="Locations mentioned")
+    dates: List[str] = Field(description="Dates mentioned")
+
+PROMPT = """
+Extract all named entities from the text.
+If there are no entities of some type, return an empty list.
+"""
+
+result = dataframeit(df, Entities, PROMPT, text_column='text')
+```
+
+## Text Summarization
+
+```python
+from pydantic import BaseModel, Field
+
+class Summary(BaseModel):
+    summary: str = Field(description="Summary in up to 50 words")
+    key_points: list[str] = Field(description="List of 3-5 main points")
+    main_topic: str = Field(description="Central topic in one word")
+
+PROMPT = """
+Analyze the text and extract a concise summary.
+Identify the main points and central topic.
+"""
+
+result = dataframeit(df, Summary, PROMPT, text_column='text')
+```
+
+## Using Different Input Types
+
+### With List
+
+```python
+texts = ['Text 1', 'Text 2', 'Text 3']
+result = dataframeit(texts, Sentiment, PROMPT)
+# Returns DataFrame with numeric index
+```
+
+### With Dictionary
+
+```python
+documents = {
+    'doc_001': 'Content of document 1',
+    'doc_002': 'Content of document 2',
+}
+result = dataframeit(documents, Sentiment, PROMPT)
+# Returns DataFrame with keys as index
+```
+
+### With Series
+
+```python
+series = pd.Series(['Text A', 'Text B'], index=['id_1', 'id_2'])
+result = dataframeit(series, Sentiment, PROMPT)
+# Preserves original index
+```
+
+## Using Different Providers
+
+```python
+# Google Gemini (default)
+result = dataframeit(df, Model, PROMPT, text_column='text')
+
+# OpenAI
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# Anthropic Claude
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+```
+
+## Next Steps
+
+- [Structured Output](structured-output.md): Advanced Pydantic models
+- [Error Handling](error-handling.md): Retry and fallbacks
+- [Performance](performance.md): Parallelism and rate limiting

--- a/docs/en/guides/error-handling.md
+++ b/docs/en/guides/error-handling.md
@@ -1,0 +1,162 @@
+# Error Handling
+
+Configure retry, fallbacks and monitor errors in processing.
+
+## Status Columns
+
+DataFrameIt automatically adds control columns:
+
+| Column | Values | Description |
+|--------|--------|-------------|
+| `_dataframeit_status` | `'processed'`, `'error'`, `None` | Processing status |
+| `_error_details` | string or `None` | Error details |
+
+## Checking Errors
+
+```python
+from dataframeit import dataframeit
+
+result = dataframeit(df, Model, PROMPT, text_column='text')
+
+# Count errors
+total_errors = (result['_dataframeit_status'] == 'error').sum()
+print(f"Total errors: {total_errors}")
+
+# Filter rows with errors
+errors = result[result['_dataframeit_status'] == 'error']
+for idx, row in errors.iterrows():
+    print(f"Row {idx}: {row['_error_details']}")
+
+# Filter only successes
+success = result[result['_dataframeit_status'] == 'processed']
+success.to_excel('clean_result.xlsx', index=False)
+```
+
+## Configuring Retry
+
+DataFrameIt uses exponential backoff for automatic retry:
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    max_retries=5,        # Maximum attempts (default: 3)
+    base_delay=2.0,       # Initial delay in seconds (default: 1.0)
+    max_delay=60.0        # Maximum delay in seconds (default: 30.0)
+)
+```
+
+**How backoff works:**
+
+```
+Attempt 1: fails → wait 2s
+Attempt 2: fails → wait 4s
+Attempt 3: fails → wait 8s
+Attempt 4: fails → wait 16s
+Attempt 5: fails → wait 32s (limited to 60s)
+Attempt 6: fails → mark as error
+```
+
+## Error Types
+
+### Transient Errors (automatic retry)
+
+- **Rate limit (429)**: Too many requests
+- **Timeout**: Server took too long
+- **Connection error**: Network issues
+- **5xx errors**: Server problems
+
+### Permanent Errors (no retry)
+
+- **Validation error**: Response doesn't match Pydantic model
+- **Authentication error (401/403)**: Invalid API key
+- **Parsing error**: Malformed response
+
+## Incremental Processing
+
+For large datasets, use `resume=True` to continue from where you left off:
+
+```python
+# First run
+result = dataframeit(df, Model, PROMPT, text_column='text', resume=True)
+result.to_excel('partial.xlsx', index=False)
+
+# If interrupted, load and continue
+df = pd.read_excel('partial.xlsx')
+result = dataframeit(df, Model, PROMPT, text_column='text', resume=True)
+result.to_excel('complete.xlsx', index=False)
+```
+
+!!! tip "How it works"
+    With `resume=True`, DataFrameIt skips rows that already have `_dataframeit_status == 'processed'`.
+
+## Reprocessing Errors
+
+```python
+# Load result with errors
+df = pd.read_excel('result.xlsx')
+
+# Clear status of error rows to reprocess
+df.loc[df['_dataframeit_status'] == 'error', '_dataframeit_status'] = None
+df.loc[df['_error_details'].notna(), '_error_details'] = None
+
+# Reprocess only rows without status
+result = dataframeit(df, Model, PROMPT, text_column='text', resume=True)
+```
+
+## Strategies to Reduce Errors
+
+### 1. Use Rate Limiting
+
+```python
+# Prevents rate limit errors
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    rate_limit_delay=1.0  # 1 second between requests
+)
+```
+
+### 2. Simplify the Model
+
+```python
+# Very complex model may fail
+class ComplexModel(BaseModel):
+    field1: str
+    field2: List[SubModel]
+    field3: Dict[str, AnotherModel]  # Avoid if possible
+
+# Simpler model = fewer errors
+class SimpleModel(BaseModel):
+    field1: str
+    field2: List[str]
+```
+
+### 3. Improve the Prompt
+
+```python
+# Vague prompt
+BAD_PROMPT = "Analyze the text."
+
+# Clear prompt
+GOOD_PROMPT = """
+Analyze the text and extract:
+1. Overall sentiment (positive, negative, or neutral)
+2. Classification confidence (high, medium, or low)
+
+If the text is ambiguous, classify as neutral with low confidence.
+"""
+```
+
+### 4. Use More Capable Models
+
+```python
+# If errors persist, try a more capable model
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    model='gemini-1.5-pro'  # More capable than flash
+)
+```

--- a/docs/en/guides/performance.md
+++ b/docs/en/guides/performance.md
@@ -1,0 +1,200 @@
+# Performance
+
+Optimize processing with parallelism, rate limiting, and token tracking.
+
+## Parallel Processing
+
+Use `parallel_requests` to speed up processing:
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    parallel_requests=5  # 5 simultaneous requests
+)
+```
+
+### Recommendations by Size
+
+| Dataset | Configuration |
+|---------|---------------|
+| < 50 rows | `parallel_requests=1` (default) |
+| 50-500 rows | `parallel_requests=3` to `5` |
+| > 500 rows | `parallel_requests=5` to `10` |
+
+### Auto-reduction on Rate Limits
+
+When a 429 error is detected, DataFrameIt automatically reduces workers:
+
+```
+Start: 10 workers
+Rate limit detected → 5 workers
+Rate limit detected → 2 workers
+Rate limit detected → 1 worker
+```
+
+!!! info "Safety"
+    Workers are only **reduced**, never automatically increased. This prevents unexpected costs.
+
+## Rate Limiting
+
+Use `rate_limit_delay` to prevent rate limit errors:
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    rate_limit_delay=1.0  # 1 second between requests
+)
+```
+
+### Calculating Ideal Delay
+
+```
+delay = 60 / requests_per_minute
+
+Examples:
+- 60 req/min  → delay = 1.0s
+- 500 req/min → delay = 0.12s
+- 50 req/min  → delay = 1.2s
+```
+
+### By Provider
+
+| Provider | Free Tier | Recommended Delay |
+|----------|-----------|-------------------|
+| Google Gemini | 60 req/min | 1.0s |
+| OpenAI (Tier 1) | 500 req/min | 0.15s |
+| Anthropic (Free) | 50 req/min | 1.2s |
+
+### Combining with Parallelism
+
+```python
+# 5 workers + delay between requests
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    parallel_requests=5,
+    rate_limit_delay=0.5
+)
+```
+
+## Token Tracking
+
+Monitor usage and costs with `track_tokens=True`:
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    track_tokens=True
+)
+
+# At the end, displays:
+# ============================================================
+# TOKEN USAGE STATISTICS
+# ============================================================
+# Model: gemini-2.0-flash
+# Total tokens: 15,432
+#   • Input:  12,345 tokens
+#   • Output: 3,087 tokens
+# ============================================================
+```
+
+### Added Columns
+
+| Column | Description |
+|--------|-------------|
+| `_input_tokens` | Input tokens per row |
+| `_output_tokens` | Output tokens per row |
+| `_total_tokens` | Total per row |
+
+### Calculating Costs
+
+```python
+result = dataframeit(df, Model, PROMPT, text_column='text', track_tokens=True)
+
+# Example: Gemini 2.0 Flash prices
+price_input = 0.075 / 1_000_000   # $0.075 per 1M tokens
+price_output = 0.30 / 1_000_000   # $0.30 per 1M tokens
+
+cost_input = result['_input_tokens'].sum() * price_input
+cost_output = result['_output_tokens'].sum() * price_output
+total_cost = cost_input + cost_output
+
+print(f"Estimated cost: ${total_cost:.4f}")
+```
+
+## Throughput Metrics
+
+DataFrameIt displays metrics automatically:
+
+```
+============================================================
+THROUGHPUT METRICS
+============================================================
+Total time: 45.2s
+Parallel workers: 5
+Requests: 100
+  - RPM (req/min): 132.7
+  - TPM (tokens/min): 20,478
+============================================================
+```
+
+Use these metrics to calibrate `parallel_requests` for your account.
+
+## Optimized Configurations
+
+### For Maximum Speed
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    parallel_requests=10,     # Many workers
+    rate_limit_delay=0.0,     # No delay
+    max_retries=5,            # Aggressive retry
+    track_tokens=True
+)
+```
+
+### For Stability
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    parallel_requests=3,      # Few workers
+    rate_limit_delay=1.0,     # Conservative delay
+    max_retries=3,
+    base_delay=2.0,
+    track_tokens=True
+)
+```
+
+### For Economy
+
+```python
+result = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    text_column='text',
+    parallel_requests=1,      # Sequential
+    rate_limit_delay=1.5,     # High delay
+    model='gemini-2.0-flash', # Cheap model
+    track_tokens=True
+)
+```

--- a/docs/en/guides/providers.md
+++ b/docs/en/guides/providers.md
@@ -1,0 +1,195 @@
+# Providers
+
+Configure different LLM providers via LangChain.
+
+## Supported Providers
+
+| Provider | Identifier | Popular Models |
+|----------|------------|----------------|
+| Google | `google_genai` | gemini-2.0-flash, gemini-1.5-pro |
+| OpenAI | `openai` | gpt-4o, gpt-4o-mini, o1, o3-mini |
+| Anthropic | `anthropic` | claude-3-5-sonnet, claude-3-opus |
+| Cohere | `cohere` | command-r, command-r-plus |
+| Mistral | `mistral` | mistral-large, mistral-small |
+
+## Google Gemini (Default)
+
+```bash
+pip install dataframeit[google]
+export GOOGLE_API_KEY="your-key"
+```
+
+```python
+# Default - no need to specify
+result = dataframeit(df, Model, PROMPT, text_column='text')
+
+# Explicit
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='google_genai',
+    model='gemini-2.0-flash'
+)
+
+# With extra parameters
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='google_genai',
+    model='gemini-1.5-pro',
+    model_kwargs={
+        'temperature': 0.2,
+        'top_p': 0.9
+    }
+)
+```
+
+### Recommended Models
+
+| Model | Use | Cost |
+|-------|-----|------|
+| `gemini-2.0-flash` | General use, fast | Low |
+| `gemini-1.5-flash` | General use, stable | Low |
+| `gemini-1.5-pro` | Complex tasks | Medium |
+
+## OpenAI
+
+```bash
+pip install dataframeit[openai]
+export OPENAI_API_KEY="your-key"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# With reasoning (o1, o3 models)
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='o3-mini',
+    model_kwargs={
+        'reasoning_effort': 'medium'  # 'low', 'medium', 'high'
+    }
+)
+```
+
+### Recommended Models
+
+| Model | Use | Cost |
+|-------|-----|------|
+| `gpt-4o-mini` | General use, economical | Low |
+| `gpt-4o` | High quality | High |
+| `o3-mini` | Reasoning, complex problems | Medium |
+
+## Anthropic Claude
+
+```bash
+pip install dataframeit[anthropic]
+export ANTHROPIC_API_KEY="your-key"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+
+# With max_tokens
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022',
+    model_kwargs={
+        'max_tokens': 4096
+    }
+)
+```
+
+### Recommended Models
+
+| Model | Use | Cost |
+|-------|-----|------|
+| `claude-3-5-sonnet-20241022` | General use, excellent quality | Medium |
+| `claude-3-opus-20240229` | Maximum quality | High |
+| `claude-3-haiku-20240307` | Fast, economical | Low |
+
+## Cohere
+
+```bash
+pip install langchain-cohere
+export COHERE_API_KEY="your-key"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='cohere',
+    model='command-r-plus'
+)
+```
+
+## Mistral
+
+```bash
+pip install langchain-mistralai
+export MISTRAL_API_KEY="your-key"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='mistral',
+    model='mistral-large-latest'
+)
+```
+
+## Price Comparison (Approximate)
+
+| Provider | Model | Input (1M tokens) | Output (1M tokens) |
+|----------|-------|-------------------|-------------------|
+| Google | gemini-2.0-flash | $0.075 | $0.30 |
+| Google | gemini-1.5-pro | $1.25 | $5.00 |
+| OpenAI | gpt-4o-mini | $0.15 | $0.60 |
+| OpenAI | gpt-4o | $2.50 | $10.00 |
+| Anthropic | claude-3-5-sonnet | $3.00 | $15.00 |
+| Anthropic | claude-3-haiku | $0.25 | $1.25 |
+
+!!! note "Prices change"
+    Check current prices on provider official websites.
+
+## Passing API Key Directly
+
+If you prefer not to use environment variables:
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='gpt-4o-mini',
+    api_key='sk-...'  # Your key directly
+)
+```
+
+!!! warning "Security"
+    Avoid putting API keys directly in code. Prefer environment variables.
+
+## Common Parameters (model_kwargs)
+
+| Parameter | Description | Providers |
+|-----------|-------------|-----------|
+| `temperature` | Creativity (0-1) | All |
+| `top_p` | Nucleus sampling | All |
+| `max_tokens` | Output limit | All |
+| `reasoning_effort` | Reasoning effort | OpenAI (o1, o3) |

--- a/docs/en/guides/structured-output.md
+++ b/docs/en/guides/structured-output.md
@@ -1,0 +1,174 @@
+# Structured Output
+
+Learn to create advanced Pydantic models for complex extractions.
+
+## Field Types
+
+### Required Fields
+
+```python
+from pydantic import BaseModel, Field
+
+class Model(BaseModel):
+    # Required without default
+    title: str = Field(description="Document title")
+
+    # Required with validation
+    score: int = Field(ge=1, le=10, description="Score from 1 to 10")
+```
+
+### Optional Fields
+
+```python
+from typing import Optional
+
+class Model(BaseModel):
+    # Optional - can be None
+    notes: Optional[str] = Field(
+        default=None,
+        description="Additional notes, if any"
+    )
+```
+
+### Fixed Value Fields (Literal)
+
+```python
+from typing import Literal
+
+class Model(BaseModel):
+    # Only accepts these values
+    priority: Literal['low', 'medium', 'high', 'critical']
+
+    # Multiple options
+    status: Literal['pending', 'in_progress', 'completed', 'cancelled']
+```
+
+!!! tip "When to use Literal"
+    Use `Literal` whenever possible values are known and finite. This:
+
+    - Forces the LLM to choose from valid options
+    - Avoids unwanted variations (e.g., "High" vs "high" vs "HIGH")
+    - Makes subsequent analysis easier
+
+### Lists
+
+```python
+from typing import List
+
+class Model(BaseModel):
+    # List of strings
+    tags: List[str] = Field(description="Relevant tags")
+
+    # List of objects
+    items: List[Item] = Field(description="List of extracted items")
+```
+
+## Nested Models
+
+For complex structures, use nested models:
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Literal
+
+class Address(BaseModel):
+    street: str
+    city: str
+    state: str
+    zip_code: Optional[str] = None
+
+class Contact(BaseModel):
+    name: str
+    email: Optional[str] = None
+    phone: Optional[str] = None
+    address: Optional[Address] = None
+
+class Company(BaseModel):
+    name: str
+    tax_id: Optional[str] = None
+    contacts: List[Contact] = Field(description="List of company contacts")
+    sector: Literal['technology', 'health', 'finance', 'retail', 'other']
+```
+
+## Real Example: Legal Analysis
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Literal
+
+class Party(BaseModel):
+    """Party involved in the case."""
+    name: str = Field(description="Full name of the party")
+    type: Literal['plaintiff', 'defendant', 'third_party'] = Field(description="Party type")
+    tax_id: Optional[str] = Field(default=None, description="Tax ID")
+
+class Claim(BaseModel):
+    """Claim made in the case."""
+    description: str = Field(description="Claim description")
+    amount: Optional[float] = Field(default=None, description="Amount in USD")
+    granted: Optional[bool] = Field(default=None, description="Whether it was granted")
+
+class CourtDecision(BaseModel):
+    """Complete analysis of a court decision."""
+
+    # Identification
+    case_number: str = Field(description="Case number")
+    court: str = Field(description="Court (e.g., Supreme Court, District Court)")
+    decision_date: str = Field(description="Decision date (YYYY-MM-DD)")
+
+    # Parties
+    parties: List[Party] = Field(description="Parties involved")
+
+    # Merit
+    decision_type: Literal['judgment', 'ruling', 'order', 'interlocutory']
+    outcome: Literal['granted', 'denied', 'partially_granted', 'dismissed']
+
+    # Claims
+    claims: List[Claim] = Field(description="Claims analyzed")
+
+    # Summary
+    summary: str = Field(description="Decision summary in up to 100 words")
+    legal_grounds: List[str] = Field(description="Main legal grounds")
+
+PROMPT = """
+Analyze the court decision below and extract all relevant information.
+Be precise with dates, amounts, and names.
+If information is not available, use null.
+"""
+
+result = dataframeit(df_decisions, CourtDecision, PROMPT, text_column='text')
+```
+
+## Custom Validations
+
+```python
+from pydantic import BaseModel, Field, field_validator
+
+class Document(BaseModel):
+    ssn: str = Field(description="SSN in format XXX-XX-XXXX")
+    email: str = Field(description="Valid email")
+
+    @field_validator('ssn')
+    @classmethod
+    def validate_ssn(cls, v):
+        # Remove non-numeric characters
+        numbers = ''.join(filter(str.isdigit, v))
+        if len(numbers) != 9:
+            raise ValueError('SSN must have 9 digits')
+        return v
+```
+
+!!! warning "Be careful with validations"
+    Very restrictive validations can cause frequent errors. Use sparingly.
+
+## Best Practices
+
+1. **Use clear descriptions**: The LLM uses descriptions to understand what to extract
+
+2. **Prefer Literal over str**: When values are known, use `Literal`
+
+3. **Use Optional for uncertain fields**: If information may not exist, mark as `Optional`
+
+4. **Break down complex models**: Use nested models for better organization
+
+5. **Test with examples**: Validate your model with real texts before processing everything

--- a/docs/en/guides/web-search.md
+++ b/docs/en/guides/web-search.md
@@ -1,0 +1,170 @@
+# Web Search
+
+Enrich your data with web search using Tavily.
+
+## Overview
+
+DataFrameIt can search the web for information to complement the analysis of each text. This is useful when you need additional context not present in the original text.
+
+## Setup
+
+### 1. Install Dependency
+
+```bash
+pip install dataframeit[search]
+# or
+pip install langchain-tavily
+```
+
+### 2. Configure API Key
+
+```bash
+export TAVILY_API_KEY="your-tavily-key"
+```
+
+Get your key at: [Tavily](https://tavily.com/)
+
+## Basic Usage
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class CompanyInfo(BaseModel):
+    sector: Literal['technology', 'health', 'finance', 'retail', 'other']
+    description: str = Field(description="Brief company description")
+    founded: str = Field(description="Year founded, if found")
+
+# Data with company names
+df = pd.DataFrame({
+    'text': ['Microsoft', 'Stripe', 'DoorDash']
+})
+
+PROMPT = """
+Based on available information and web search,
+extract information about the mentioned company.
+"""
+
+# Enable web search with use_search=True
+result = dataframeit(
+    df,
+    CompanyInfo,
+    PROMPT,
+    text_column='text',
+    use_search=True,      # Enable web search
+    max_results=5         # Number of results per search
+)
+```
+
+## Search Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `use_search` | bool | `False` | Enable web search via Tavily |
+| `search_per_field` | bool | `False` | Execute separate search for each model field |
+| `max_results` | int | `5` | Results per search (1-20) |
+| `search_depth` | str | `'basic'` | `'basic'` (1 credit) or `'advanced'` (2 credits) |
+
+## Examples
+
+### Basic Search
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    use_search=True
+)
+```
+
+### Search per Field
+
+When the model has many fields, it can be useful to do separate searches:
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    use_search=True,
+    search_per_field=True  # One search per model field
+)
+```
+
+### Deep Search
+
+```python
+# More detailed search (slower, more expensive)
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    use_search=True,
+    search_depth='advanced',
+    max_results=10
+)
+```
+
+## Use Case: Fact Checking
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List
+
+class FactCheck(BaseModel):
+    claim: str = Field(description="The original claim")
+    verdict: Literal['true', 'false', 'partially_true', 'inconclusive']
+    sources: List[str] = Field(description="Sources supporting the verdict")
+    explanation: str = Field(description="Explanation of the verdict")
+
+PROMPT = """
+Verify the truthfulness of the claim using web search information.
+Cite the sources found.
+"""
+
+result = dataframeit(
+    df_claims,
+    FactCheck,
+    PROMPT,
+    text_column='text',
+    use_search=True,
+    max_results=5,
+    search_depth='advanced'
+)
+```
+
+## Use Case: Lead Enrichment
+
+```python
+class EnrichedLead(BaseModel):
+    company: str
+    website: str = Field(description="Official website")
+    linkedin: str = Field(description="LinkedIn URL")
+    size: Literal['startup', 'sme', 'enterprise']
+    technologies: List[str] = Field(description="Technologies used")
+
+result = dataframeit(
+    df_leads,
+    EnrichedLead,
+    "Research information about the company.",
+    text_column='text',
+    use_search=True,
+    max_results=3
+)
+```
+
+## Costs and Limits
+
+!!! warning "Watch costs"
+    Each DataFrame row makes a web search. For large datasets, this can generate significant costs on the Tavily API.
+
+- **Free tier**: 1000 searches/month
+- **Basic search**: ~$0.01 per search
+- **Advanced search**: ~$0.02 per search
+
+### Tips to Save
+
+1. Use `max_results=3` to `5` (enough for most cases)
+2. Prefer `search_depth='basic'`
+3. Filter your DataFrame before processing
+4. Use `search_per_field=False` when possible

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,91 @@
+# DataFrameIt
+
+**Enrich DataFrames with LLMs in a simple and structured way.**
+
+DataFrameIt is a Python library that processes text in DataFrames and extracts structured information using Large Language Models (LLMs). Define what you want to extract with Pydantic, and the library handles the rest.
+
+## Why use it?
+
+- **Simple**: One function, one Pydantic model, one prompt. Done.
+- **Structured**: Outputs automatically validated with Pydantic
+- **Resilient**: Automatic retry, rate limiting, parallel processing
+- **Flexible**: Supports Gemini, OpenAI, Anthropic, Cohere, Mistral and more
+
+## Quick Installation
+
+```bash
+pip install dataframeit[google]  # For Google Gemini (recommended)
+```
+
+## Example in 30 Seconds
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Define what you want to extract
+class Sentiment(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+    confidence: Literal['high', 'medium', 'low']
+
+# 2. Your data
+df = pd.DataFrame({
+    'text': [
+        'Excellent product! Exceeded expectations.',
+        'Terrible service, never buying again.',
+        'Delivery ok, average product.'
+    ]
+})
+
+# 3. Process!
+result = dataframeit(df, Sentiment, "Analyze the sentiment of the text.", text_column='text')
+print(result)
+```
+
+**Output:**
+
+| text | sentiment | confidence |
+|------|-----------|------------|
+| Excellent product! Exceeded expectations. | positive | high |
+| Terrible service, never buying again. | negative | high |
+| Delivery ok, average product. | neutral | medium |
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :material-download:{ .lg .middle } **Installation**
+
+    ---
+
+    Set up the library with your preferred provider
+
+    [:octicons-arrow-right-24: Installation guide](getting-started/installation.md)
+
+-   :material-rocket-launch:{ .lg .middle } **Quickstart**
+
+    ---
+
+    Create your first project in 5 minutes
+
+    [:octicons-arrow-right-24: Quickstart](getting-started/quickstart.md)
+
+-   :material-book-open-variant:{ .lg .middle } **Guides**
+
+    ---
+
+    Learn advanced features like parallelism and retry
+
+    [:octicons-arrow-right-24: View guides](guides/basic-usage.md)
+
+-   :material-robot:{ .lg .middle } **LLM Reference**
+
+    ---
+
+    Compact documentation optimized for code assistants
+
+    [:octicons-arrow-right-24: LLM Reference](reference/llm-reference.md)
+
+</div>

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -1,0 +1,210 @@
+# API Reference
+
+Complete documentation of all public functions and classes.
+
+## dataframeit()
+
+Main function to process texts with LLMs.
+
+```python
+def dataframeit(
+    data,
+    questions,
+    prompt,
+    resume=True,
+    reprocess_columns=None,
+    model='gemini-3.0-flash',
+    provider='google_genai',
+    status_column=None,
+    text_column=None,
+    api_key=None,
+    max_retries=3,
+    base_delay=1.0,
+    max_delay=30.0,
+    rate_limit_delay=0.0,
+    track_tokens=True,
+    model_kwargs=None,
+    parallel_requests=1,
+    # Web search parameters
+    use_search=False,
+    search_per_field=False,
+    max_results=5,
+    search_depth="basic",
+) -> Any
+```
+
+### Parameters
+
+#### Data
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `data` | DataFrame, Series, list, dict | Yes | Data containing texts to process |
+| `questions` | Pydantic BaseModel | Yes | Pydantic model defining fields to extract |
+| `prompt` | str | Yes | Prompt template. Use `{texto}` to position text |
+| `text_column` | str | DataFrame: Yes | Column name with texts. Default: `'texto'` |
+
+#### Processing
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `resume` | bool | `True` | Continue from where it stopped (skips processed rows) |
+| `reprocess_columns` | list | `None` | List of columns to force reprocessing |
+| `status_column` | str | `None` | Custom name for status column |
+
+#### Model
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model` | str | `'gemini-3.0-flash'` | LLM model name |
+| `provider` | str | `'google_genai'` | LangChain provider |
+| `api_key` | str | `None` | API key (uses env var if None) |
+| `model_kwargs` | dict | `None` | Extra parameters (temperature, etc.) |
+
+#### Resilience
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max_retries` | int | `3` | Maximum attempts per row |
+| `base_delay` | float | `1.0` | Initial retry delay (seconds) |
+| `max_delay` | float | `30.0` | Maximum retry delay (seconds) |
+| `rate_limit_delay` | float | `0.0` | Delay between requests (seconds) |
+
+#### Performance
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `parallel_requests` | int | `1` | Parallel workers (1 = sequential) |
+| `track_tokens` | bool | `True` | Track token usage |
+
+#### Web Search
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `use_search` | bool | `False` | Enable web search via Tavily |
+| `search_per_field` | bool | `False` | Execute separate search per field |
+| `max_results` | int | `5` | Results per search (1-20) |
+| `search_depth` | str | `'basic'` | `'basic'` or `'advanced'` |
+
+### Return
+
+Returns data in the same format as input with extracted columns added.
+
+| Input | Output |
+|-------|--------|
+| `pd.DataFrame` | `pd.DataFrame` with Pydantic model columns |
+| `pl.DataFrame` | `pl.DataFrame` with Pydantic model columns |
+| `pd.Series` | `pd.DataFrame` preserving index |
+| `pl.Series` | `pl.DataFrame` |
+| `list` | `pd.DataFrame` with numeric index |
+| `dict` | `pd.DataFrame` with keys as index |
+
+### Added Columns
+
+| Column | Description |
+|--------|-------------|
+| `_dataframeit_status` | `'processed'`, `'error'`, or `None` |
+| `_error_details` | Error details (when applicable) |
+| `_input_tokens` | Input tokens (if `track_tokens=True`) |
+| `_output_tokens` | Output tokens (if `track_tokens=True`) |
+| `_total_tokens` | Total tokens (if `track_tokens=True`) |
+
+### Examples
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class Sentiment(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+
+df = pd.DataFrame({'text': ['Great!', 'Terrible!']})
+
+# Basic
+result = dataframeit(df, Sentiment, "Analyze the sentiment.", text_column='text')
+
+# With configurations
+result = dataframeit(
+    df,
+    Sentiment,
+    "Analyze the sentiment.",
+    text_column='text',
+    provider='openai',
+    model='gpt-4o-mini',
+    parallel_requests=5,
+    rate_limit_delay=0.5,
+    max_retries=5
+)
+```
+
+---
+
+## read_df()
+
+Reads files in various formats to DataFrame.
+
+```python
+def read_df(path: str, **kwargs) -> pd.DataFrame
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `path` | str | File path |
+| `**kwargs` | | Arguments passed to pandas |
+
+### Supported Formats
+
+- `.xlsx`, `.xls` - Excel
+- `.csv` - CSV
+- `.json` - JSON
+- `.parquet` - Parquet
+
+### Example
+
+```python
+from dataframeit import read_df
+
+df = read_df('data.xlsx')
+df = read_df('data.csv', encoding='utf-8')
+```
+
+---
+
+## normalize_value()
+
+Normalizes Python values to pandas-compatible types.
+
+```python
+def normalize_value(value: Any) -> Any
+```
+
+Converts:
+- `tuple` → `list`
+- Pydantic objects → `dict`
+- Nested values recursively
+
+---
+
+## normalize_complex_columns()
+
+Normalizes columns with complex types in a DataFrame.
+
+```python
+def normalize_complex_columns(df: pd.DataFrame, complex_fields: list) -> pd.DataFrame
+```
+
+---
+
+## get_complex_fields()
+
+Identifies complex fields in a Pydantic model.
+
+```python
+def get_complex_fields(pydantic_model) -> list[str]
+```
+
+Returns list of field names containing `List`, `Tuple`, or nested models.

--- a/docs/en/reference/llm-reference.md
+++ b/docs/en/reference/llm-reference.md
@@ -1,0 +1,264 @@
+# LLM Reference
+
+This page contains all the information needed to use DataFrameIt in a single compact page, optimized for code assistants.
+
+---
+
+## What it is
+
+DataFrameIt processes texts in DataFrames using LLMs and extracts structured information defined by Pydantic models.
+
+## Installation
+
+```bash
+pip install dataframeit[google]    # Google Gemini (default)
+pip install dataframeit[openai]    # OpenAI
+pip install dataframeit[anthropic] # Anthropic Claude
+```
+
+**Environment variables:**
+```bash
+export GOOGLE_API_KEY="..."     # For Gemini
+export OPENAI_API_KEY="..."     # For OpenAI
+export ANTHROPIC_API_KEY="..."  # For Anthropic
+```
+
+---
+
+## Function Signature
+
+```python
+from dataframeit import dataframeit
+
+result = dataframeit(
+    data,                    # DataFrame, Series, list or dict
+    questions,               # Pydantic model
+    prompt,                  # Prompt template
+    text_column='text',      # Column with texts (required for DataFrame)
+    model='gemini-3.0-flash',
+    provider='google_genai', # 'google_genai', 'openai', 'anthropic'
+    resume=True,             # Continue from where it stopped
+    parallel_requests=1,     # Parallel workers
+    rate_limit_delay=0.0,    # Delay between requests (seconds)
+    max_retries=3,           # Retry attempts on error
+    track_tokens=True,       # Track token usage
+    api_key=None,            # API key (uses env var if None)
+    model_kwargs=None,       # Extra parameters (temperature, etc)
+    # Web search (requires TAVILY_API_KEY)
+    use_search=False,        # Enable web search
+    search_per_field=False,  # Separate search per field
+    max_results=5,           # Results per search
+    search_depth='basic',    # 'basic' or 'advanced'
+)
+```
+
+---
+
+## Complete Example
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List, Optional
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Define Pydantic model
+class Analysis(BaseModel):
+    sentiment: Literal['positive', 'negative', 'neutral']
+    confidence: Literal['high', 'medium', 'low']
+    topics: List[str] = Field(description="Main topics")
+    summary: str = Field(description="Summary in one sentence")
+
+# 2. Data
+df = pd.DataFrame({
+    'text': [
+        'Excellent product! Fast delivery.',
+        'Terrible service, took too long.',
+        'Ok, nothing special.'
+    ]
+})
+
+# 3. Process
+result = dataframeit(
+    df,
+    Analysis,
+    "Analyze the text and extract the requested information.",
+    text_column='text'
+)
+
+# 4. Result contains columns: text, sentiment, confidence, topics, summary
+print(result)
+```
+
+---
+
+## Supported Input Types
+
+```python
+# DataFrame (requires text_column)
+df = pd.DataFrame({'text': ['A', 'B']})
+result = dataframeit(df, Model, PROMPT, text_column='text')
+
+# List (no text_column needed)
+texts = ['Text 1', 'Text 2']
+result = dataframeit(texts, Model, PROMPT)
+
+# Dictionary (keys become index)
+docs = {'id1': 'Text 1', 'id2': 'Text 2'}
+result = dataframeit(docs, Model, PROMPT)
+
+# Series (preserves index)
+series = pd.Series(['A', 'B'], index=['x', 'y'])
+result = dataframeit(series, Model, PROMPT)
+```
+
+---
+
+## Pydantic Models
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List, Optional
+
+# Fields with fixed values
+class Example(BaseModel):
+    category: Literal['A', 'B', 'C']
+
+# Optional fields
+class Example(BaseModel):
+    notes: Optional[str] = Field(default=None, description="Observations")
+
+# Lists
+class Example(BaseModel):
+    tags: List[str] = Field(description="List of tags")
+
+# Nested models
+class Address(BaseModel):
+    city: str
+    state: str
+
+class Person(BaseModel):
+    name: str
+    address: Optional[Address] = None
+```
+
+---
+
+## Providers
+
+```python
+# Google Gemini (default)
+result = dataframeit(df, Model, PROMPT, text_column='text')
+
+# OpenAI
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# Anthropic
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+
+# With extra parameters
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='openai',
+    model='o3-mini',
+    model_kwargs={'reasoning_effort': 'medium'}
+)
+```
+
+---
+
+## Performance
+
+```python
+# Parallel processing
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    parallel_requests=5  # 5 simultaneous workers
+)
+
+# Rate limiting (prevents 429 error)
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    rate_limit_delay=1.0  # 1 second between requests
+)
+
+# Combined
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    parallel_requests=5,
+    rate_limit_delay=0.5
+)
+```
+
+---
+
+## Error Handling
+
+```python
+result = dataframeit(df, Model, PROMPT, text_column='text', max_retries=5)
+
+# Check errors
+errors = result[result['_dataframeit_status'] == 'error']
+print(errors['_error_details'])
+
+# Filter success
+success = result[result['_dataframeit_status'] == 'processed']
+```
+
+---
+
+## Automatically Added Columns
+
+| Column | Description |
+|--------|-------------|
+| `_dataframeit_status` | `'processed'`, `'error'`, `None` |
+| `_error_details` | Error message |
+| `_input_tokens` | Input tokens |
+| `_output_tokens` | Output tokens |
+| `_total_tokens` | Total tokens |
+
+---
+
+## Incremental Processing
+
+```python
+# Process and save
+result = dataframeit(df, Model, PROMPT, text_column='text', resume=True)
+result.to_excel('partial.xlsx', index=False)
+
+# Load and continue
+df = pd.read_excel('partial.xlsx')
+result = dataframeit(df, Model, PROMPT, text_column='text', resume=True)
+```
+
+---
+
+## Prompt Template
+
+```python
+# Simple - text added at the end
+PROMPT = "Classify the sentiment of the text."
+
+# With placeholder - control the position
+PROMPT = """
+Analyze the document below:
+
+{texto}
+
+Extract the requested information.
+"""
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,146 @@
+# Exemplos
+
+Exemplos práticos em Jupyter Notebooks para aprender DataFrameIt.
+
+## Notebooks Disponíveis
+
+Os exemplos estão organizados do básico ao avançado. Recomendamos seguir na ordem.
+
+### 1. Básico
+**[01_basic.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/01_basic.ipynb)**
+
+Introdução ao DataFrameIt com análise de sentimentos.
+
+- Criar modelo Pydantic simples
+- Processar DataFrame básico
+- Entender a saída
+
+```python
+from pydantic import BaseModel
+from typing import Literal
+
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+```
+
+---
+
+### 2. Tratamento de Erros
+**[02_error_handling.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/02_error_handling.ipynb)**
+
+Como lidar com erros e configurar retry.
+
+- Configurar `max_retries`, `base_delay`, `max_delay`
+- Verificar coluna `_dataframeit_status`
+- Analisar `_error_details`
+
+---
+
+### 3. Processamento Incremental
+**[03_resume.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/03_resume.ipynb)**
+
+Continuar processamento de onde parou.
+
+- Usar `resume=True`
+- Salvar e carregar resultados parciais
+- Reprocessar apenas linhas com erro
+
+---
+
+### 4. Placeholder Customizado
+**[04_custom_placeholder.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/04_custom_placeholder.ipynb)**
+
+Controlar onde o texto aparece no prompt.
+
+- Usar `{texto}` no template
+- Criar prompts complexos multi-parte
+
+---
+
+### 5. Caso Avançado: Análise Jurídica
+**[05_advanced_legal.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/05_advanced_legal.ipynb)**
+
+Exemplo real com modelo Pydantic complexo.
+
+- Modelos aninhados
+- Campos opcionais
+- Listas de objetos
+- Extração de múltiplas entidades
+
+```python
+class Parte(BaseModel):
+    nome: str
+    tipo: Literal['autor', 'reu']
+
+class Decisao(BaseModel):
+    partes: List[Parte]
+    resultado: Literal['procedente', 'improcedente']
+```
+
+---
+
+### 6. Polars
+**[06_polars.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/06_polars.ipynb)**
+
+Usar DataFrameIt com Polars ao invés de Pandas.
+
+- Entrada com `polars.DataFrame`
+- Saída preserva tipo Polars
+
+---
+
+### 7. Múltiplos Tipos de Dados
+**[07_multiple_data_types.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/07_multiple_data_types.ipynb)**
+
+Processar diferentes tipos de entrada.
+
+- Listas
+- Dicionários
+- Series
+
+---
+
+### 8. Rate Limiting
+**[08_rate_limiting.ipynb](https://github.com/bdcdo/dataframeit/blob/main/example/08_rate_limiting.ipynb)**
+
+Controlar taxa de requisições.
+
+- Configurar `rate_limit_delay`
+- Usar `parallel_requests`
+- Combinar para máxima eficiência
+
+---
+
+## Executando os Exemplos
+
+### 1. Clone o Repositório
+
+```bash
+git clone https://github.com/bdcdo/dataframeit.git
+cd dataframeit
+```
+
+### 2. Instale as Dependências
+
+```bash
+pip install dataframeit[google]
+pip install jupyter
+```
+
+### 3. Configure sua API Key
+
+```bash
+export GOOGLE_API_KEY="sua-chave"
+```
+
+### 4. Execute o Jupyter
+
+```bash
+jupyter notebook example/
+```
+
+---
+
+## Contribuindo com Exemplos
+
+Se você criou um exemplo interessante, considere contribuir! Abra uma issue ou pull request no [GitHub](https://github.com/bdcdo/dataframeit).

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,0 +1,130 @@
+# Conceitos
+
+Entenda os conceitos fundamentais do DataFrameIt.
+
+## Arquitetura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        dataframeit()                         │
+├─────────────────────────────────────────────────────────────┤
+│  Entrada           │  Processamento      │  Saída           │
+│  ─────────         │  ─────────────      │  ─────           │
+│  • DataFrame       │  • Para cada linha: │  • DataFrame     │
+│  • Series          │    1. Monta prompt  │    com colunas   │
+│  • List            │    2. Chama LLM     │    extraídas     │
+│  • Dict            │    3. Valida resp.  │                  │
+│                    │    4. Retry se erro │                  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                     LangChain + Provider                     │
+├─────────────────────────────────────────────────────────────┤
+│  Google Gemini │ OpenAI │ Anthropic │ Cohere │ Mistral      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Componentes Principais
+
+### 1. Modelo Pydantic
+
+O modelo Pydantic define **o que** você quer extrair. Cada campo vira uma coluna no DataFrame de saída.
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analise(BaseModel):
+    # Campo obrigatório com valores fixos
+    categoria: Literal['A', 'B', 'C'] = Field(
+        description="Categoria do item"
+    )
+
+    # Campo obrigatório com texto livre
+    resumo: str = Field(
+        description="Resumo em uma frase"
+    )
+
+    # Campo opcional
+    observacao: Optional[str] = Field(
+        default=None,
+        description="Observações adicionais, se houver"
+    )
+```
+
+!!! info "Por que Pydantic?"
+    - **Validação automática**: O LLM é forçado a retornar dados no formato correto
+    - **Documentação**: As descrições dos campos ajudam o LLM a entender o que extrair
+    - **Type safety**: Erros de tipo são capturados automaticamente
+
+### 2. Prompt Template
+
+O prompt define **como** o LLM deve processar cada texto.
+
+```python
+# Simples - texto é adicionado automaticamente ao final
+PROMPT = "Classifique o sentimento do texto."
+
+# Com placeholder - controle onde o texto aparece
+PROMPT = """
+Você é um analista especializado.
+
+Documento:
+{texto}
+
+Extraia as informações solicitadas do documento acima.
+"""
+```
+
+### 3. Providers via LangChain
+
+O DataFrameIt usa LangChain para abstrair diferentes provedores de LLM:
+
+| Provider | Modelos Populares | Variável de Ambiente |
+|----------|-------------------|---------------------|
+| `google_genai` | gemini-2.0-flash, gemini-1.5-pro | `GOOGLE_API_KEY` |
+| `openai` | gpt-4o, gpt-4o-mini, o1, o3-mini | `OPENAI_API_KEY` |
+| `anthropic` | claude-3-5-sonnet, claude-3-opus | `ANTHROPIC_API_KEY` |
+
+## Fluxo de Processamento
+
+```
+Para cada linha do DataFrame:
+│
+├─► 1. Monta o prompt (template + texto da linha)
+│
+├─► 2. Envia para o LLM via LangChain
+│
+├─► 3. Recebe resposta estruturada
+│
+├─► 4. Valida com Pydantic
+│   │
+│   ├─► Sucesso: marca como 'processed'
+│   │
+│   └─► Erro: retry com backoff exponencial
+│       │
+│       ├─► Sucesso após retry: marca como 'processed'
+│       │
+│       └─► Falha após max_retries: marca como 'error'
+│
+└─► 5. Adiciona campos extraídos ao DataFrame
+```
+
+## Colunas Automáticas
+
+O DataFrameIt adiciona colunas de controle automaticamente:
+
+| Coluna | Descrição |
+|--------|-----------|
+| `_dataframeit_status` | Status: `'processed'`, `'error'`, ou `None` |
+| `_error_details` | Detalhes do erro (quando status é `'error'`) |
+| `_input_tokens` | Tokens de entrada (com `track_tokens=True`) |
+| `_output_tokens` | Tokens de saída (com `track_tokens=True`) |
+| `_total_tokens` | Total de tokens (com `track_tokens=True`) |
+
+## Próximos Passos
+
+- [Uso Básico](../guides/basic-usage.md): Exemplos práticos
+- [Tratamento de Erros](../guides/error-handling.md): Configurar retry e fallbacks
+- [Performance](../guides/performance.md): Paralelismo e rate limiting

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,82 @@
+# Instalação
+
+## Instalação Básica
+
+O DataFrameIt usa [LangChain](https://langchain.com/) para suportar múltiplos provedores de LLM. Escolha o provider que deseja usar:
+
+=== "Google Gemini (Recomendado)"
+
+    ```bash
+    pip install dataframeit[google]
+    ```
+
+    Modelos: `gemini-2.0-flash`, `gemini-1.5-pro`, `gemini-1.5-flash`
+
+=== "OpenAI"
+
+    ```bash
+    pip install dataframeit[openai]
+    ```
+
+    Modelos: `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `o1`, `o3-mini`
+
+=== "Anthropic"
+
+    ```bash
+    pip install dataframeit[anthropic]
+    ```
+
+    Modelos: `claude-3-5-sonnet-20241022`, `claude-3-opus-20240229`
+
+=== "Todos os Providers"
+
+    ```bash
+    pip install dataframeit[all]
+    ```
+
+## Com Polars (Opcional)
+
+Se você usa Polars ao invés de Pandas:
+
+```bash
+pip install dataframeit[google,polars]
+```
+
+## Configuração de API Keys
+
+Configure a variável de ambiente correspondente ao seu provider:
+
+=== "Google Gemini"
+
+    ```bash
+    export GOOGLE_API_KEY="sua-chave-google"
+    ```
+
+    Obtenha sua chave em: [Google AI Studio](https://aistudio.google.com/apikey)
+
+=== "OpenAI"
+
+    ```bash
+    export OPENAI_API_KEY="sua-chave-openai"
+    ```
+
+    Obtenha sua chave em: [OpenAI Platform](https://platform.openai.com/api-keys)
+
+=== "Anthropic"
+
+    ```bash
+    export ANTHROPIC_API_KEY="sua-chave-anthropic"
+    ```
+
+    Obtenha sua chave em: [Anthropic Console](https://console.anthropic.com/)
+
+## Verificando a Instalação
+
+```python
+from dataframeit import dataframeit
+print("DataFrameIt instalado com sucesso!")
+```
+
+## Próximo Passo
+
+Agora que você instalou o DataFrameIt, veja o [Início Rápido](quickstart.md) para criar seu primeiro projeto.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,120 @@
+# Início Rápido
+
+Este guia mostra como usar o DataFrameIt em 5 minutos.
+
+## Passo 1: Defina seu Modelo Pydantic
+
+O modelo Pydantic define a estrutura dos dados que você quer extrair:
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class Sentimento(BaseModel):
+    """Análise de sentimento de um texto."""
+    sentimento: Literal['positivo', 'negativo', 'neutro'] = Field(
+        description="Sentimento geral do texto"
+    )
+    confianca: Literal['alta', 'media', 'baixa'] = Field(
+        description="Nível de confiança na classificação"
+    )
+```
+
+!!! tip "Dica"
+    Use `Literal` para campos com valores fixos. Isso garante que o LLM retorne apenas valores válidos.
+
+## Passo 2: Prepare seus Dados
+
+O DataFrameIt aceita vários tipos de entrada:
+
+=== "DataFrame"
+
+    ```python
+    import pandas as pd
+
+    df = pd.DataFrame({
+        'texto': [
+            'Produto excelente! Superou expectativas.',
+            'Péssimo atendimento, nunca mais compro.',
+            'Entrega ok, produto mediano.'
+        ]
+    })
+    ```
+
+=== "Lista"
+
+    ```python
+    textos = [
+        'Produto excelente! Superou expectativas.',
+        'Péssimo atendimento, nunca mais compro.',
+        'Entrega ok, produto mediano.'
+    ]
+    ```
+
+=== "Dicionário"
+
+    ```python
+    textos = {
+        'review_001': 'Produto excelente! Superou expectativas.',
+        'review_002': 'Péssimo atendimento, nunca mais compro.',
+        'review_003': 'Entrega ok, produto mediano.'
+    }
+    ```
+
+## Passo 3: Processe!
+
+```python
+from dataframeit import dataframeit
+
+resultado = dataframeit(
+    df,                                      # Seus dados
+    Sentimento,                              # Modelo Pydantic
+    "Analise o sentimento do texto."         # Prompt
+)
+
+print(resultado)
+```
+
+**Saída:**
+
+```
+                                       texto sentimento confianca
+0  Produto excelente! Superou expectativas.   positivo      alta
+1  Péssimo atendimento, nunca mais compro.   negativo      alta
+2            Entrega ok, produto mediano.     neutro     media
+```
+
+## Exemplo Completo
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Modelo Pydantic
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+    confianca: Literal['alta', 'media', 'baixa']
+
+# 2. Dados
+df = pd.DataFrame({
+    'texto': [
+        'Produto excelente! Superou expectativas.',
+        'Péssimo atendimento, nunca mais compro.',
+        'Entrega ok, produto mediano.'
+    ]
+})
+
+# 3. Processar
+resultado = dataframeit(df, Sentimento, "Analise o sentimento do texto.")
+
+# 4. Salvar
+resultado.to_excel('resultado.xlsx', index=False)
+```
+
+## Próximos Passos
+
+- [Conceitos](concepts.md): Entenda como o DataFrameIt funciona
+- [Uso Básico](../guides/basic-usage.md): Mais exemplos práticos
+- [Tratamento de Erros](../guides/error-handling.md): Lidando com falhas

--- a/docs/guides/basic-usage.md
+++ b/docs/guides/basic-usage.md
@@ -1,0 +1,137 @@
+# Uso Básico
+
+Exemplos práticos para casos de uso comuns.
+
+## Análise de Sentimento
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+    confianca: Literal['alta', 'media', 'baixa']
+
+df = pd.DataFrame({
+    'texto': [
+        'Adorei o produto!',
+        'Péssimo, não recomendo.',
+        'Normal, nada demais.'
+    ]
+})
+
+resultado = dataframeit(df, Sentimento, "Analise o sentimento do texto.")
+```
+
+## Classificação de Categorias
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+
+class Categoria(BaseModel):
+    categoria: Literal['tecnologia', 'saude', 'financas', 'educacao', 'outro']
+    subcategoria: str = Field(description="Subcategoria mais específica")
+
+resultado = dataframeit(
+    df,
+    Categoria,
+    "Classifique o texto na categoria mais apropriada."
+)
+```
+
+## Extração de Entidades
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+class Entidades(BaseModel):
+    pessoas: List[str] = Field(description="Nomes de pessoas mencionadas")
+    organizacoes: List[str] = Field(description="Nomes de empresas/organizações")
+    locais: List[str] = Field(description="Locais mencionados")
+    datas: List[str] = Field(description="Datas mencionadas")
+
+PROMPT = """
+Extraia todas as entidades nomeadas do texto.
+Se não houver entidades de algum tipo, retorne lista vazia.
+"""
+
+resultado = dataframeit(df, Entidades, PROMPT)
+```
+
+## Resumo de Texto
+
+```python
+from pydantic import BaseModel, Field
+
+class Resumo(BaseModel):
+    resumo: str = Field(description="Resumo em até 50 palavras")
+    pontos_chave: list[str] = Field(description="Lista de 3-5 pontos principais")
+    tema_principal: str = Field(description="Tema central em uma palavra")
+
+PROMPT = """
+Analise o texto e extraia um resumo conciso.
+Identifique os pontos principais e o tema central.
+"""
+
+resultado = dataframeit(df, Resumo, PROMPT)
+```
+
+## Usando Diferentes Tipos de Entrada
+
+### Com Lista
+
+```python
+textos = ['Texto 1', 'Texto 2', 'Texto 3']
+resultado = dataframeit(textos, Sentimento, PROMPT)
+# Retorna DataFrame com índice numérico
+```
+
+### Com Dicionário
+
+```python
+documentos = {
+    'doc_001': 'Conteúdo do documento 1',
+    'doc_002': 'Conteúdo do documento 2',
+}
+resultado = dataframeit(documentos, Sentimento, PROMPT)
+# Retorna DataFrame com chaves como índice
+```
+
+### Com Series
+
+```python
+series = pd.Series(['Texto A', 'Texto B'], index=['id_1', 'id_2'])
+resultado = dataframeit(series, Sentimento, PROMPT)
+# Preserva o índice original
+```
+
+## Usando Diferentes Providers
+
+```python
+# Google Gemini (padrão)
+resultado = dataframeit(df, Model, PROMPT)
+
+# OpenAI
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# Anthropic Claude
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+```
+
+## Próximos Passos
+
+- [Saída Estruturada](structured-output.md): Modelos Pydantic avançados
+- [Tratamento de Erros](error-handling.md): Retry e fallbacks
+- [Performance](performance.md): Paralelismo e rate limiting

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,159 @@
+# Tratamento de Erros
+
+Configure retry, fallbacks e monitore erros no processamento.
+
+## Colunas de Status
+
+O DataFrameIt adiciona automaticamente colunas de controle:
+
+| Coluna | Valores | Descrição |
+|--------|---------|-----------|
+| `_dataframeit_status` | `'processed'`, `'error'`, `None` | Status do processamento |
+| `_error_details` | string ou `None` | Detalhes do erro |
+
+## Verificando Erros
+
+```python
+from dataframeit import dataframeit
+
+resultado = dataframeit(df, Model, PROMPT)
+
+# Contar erros
+total_erros = (resultado['_dataframeit_status'] == 'error').sum()
+print(f"Total de erros: {total_erros}")
+
+# Filtrar linhas com erro
+erros = resultado[resultado['_dataframeit_status'] == 'error']
+for idx, row in erros.iterrows():
+    print(f"Linha {idx}: {row['_error_details']}")
+
+# Filtrar apenas sucesso
+sucesso = resultado[resultado['_dataframeit_status'] == 'processed']
+sucesso.to_excel('resultado_limpo.xlsx', index=False)
+```
+
+## Configurando Retry
+
+O DataFrameIt usa backoff exponencial para retry automático:
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    max_retries=5,        # Máximo de tentativas (padrão: 3)
+    base_delay=2.0,       # Delay inicial em segundos (padrão: 1.0)
+    max_delay=60.0        # Delay máximo em segundos (padrão: 30.0)
+)
+```
+
+**Como funciona o backoff:**
+
+```
+Tentativa 1: falha → espera 2s
+Tentativa 2: falha → espera 4s
+Tentativa 3: falha → espera 8s
+Tentativa 4: falha → espera 16s
+Tentativa 5: falha → espera 32s (limitado a 60s)
+Tentativa 6: falha → marca como erro
+```
+
+## Tipos de Erros
+
+### Erros Transientes (retry automático)
+
+- **Rate limit (429)**: Muitas requisições
+- **Timeout**: Servidor demorou muito
+- **Erro de conexão**: Problemas de rede
+- **Erro 5xx**: Problemas no servidor
+
+### Erros Permanentes (sem retry)
+
+- **Erro de validação**: Resposta não segue o modelo Pydantic
+- **Erro de autenticação (401/403)**: API key inválida
+- **Erro de parsing**: Resposta mal formatada
+
+## Processamento Incremental
+
+Para datasets grandes, use `resume=True` para continuar de onde parou:
+
+```python
+# Primeira execução
+resultado = dataframeit(df, Model, PROMPT, resume=True)
+resultado.to_excel('parcial.xlsx', index=False)
+
+# Se houver interrupção, carregue e continue
+df = pd.read_excel('parcial.xlsx')
+resultado = dataframeit(df, Model, PROMPT, resume=True)
+resultado.to_excel('completo.xlsx', index=False)
+```
+
+!!! tip "Como funciona"
+    Com `resume=True`, o DataFrameIt pula linhas que já têm `_dataframeit_status == 'processed'`.
+
+## Reprocessando Erros
+
+```python
+# Carregar resultado com erros
+df = pd.read_excel('resultado.xlsx')
+
+# Limpar status das linhas com erro para reprocessar
+df.loc[df['_dataframeit_status'] == 'error', '_dataframeit_status'] = None
+df.loc[df['_error_details'].notna(), '_error_details'] = None
+
+# Reprocessar apenas as linhas sem status
+resultado = dataframeit(df, Model, PROMPT, resume=True)
+```
+
+## Estratégias para Reduzir Erros
+
+### 1. Use Rate Limiting
+
+```python
+# Previne erros de rate limit
+resultado = dataframeit(
+    df, Model, PROMPT,
+    rate_limit_delay=1.0  # 1 segundo entre requisições
+)
+```
+
+### 2. Simplifique o Modelo
+
+```python
+# Modelo muito complexo pode falhar
+class ModeloComplexo(BaseModel):
+    campo1: str
+    campo2: List[SubModelo]
+    campo3: Dict[str, OutroModelo]  # Evite se possível
+
+# Modelo mais simples = menos erros
+class ModeloSimples(BaseModel):
+    campo1: str
+    campo2: List[str]
+```
+
+### 3. Melhore o Prompt
+
+```python
+# Prompt vago
+PROMPT_RUIM = "Analise o texto."
+
+# Prompt claro
+PROMPT_BOM = """
+Analise o texto e extraia:
+1. Sentimento geral (positivo, negativo ou neutro)
+2. Confiança na classificação (alta, média ou baixa)
+
+Se o texto for ambíguo, classifique como neutro com confiança baixa.
+"""
+```
+
+### 4. Use Modelos Mais Capazes
+
+```python
+# Se erros persistem, tente um modelo mais capaz
+resultado = dataframeit(
+    df, Model, PROMPT,
+    model='gemini-1.5-pro'  # Mais capaz que flash
+)
+```

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,0 +1,193 @@
+# Performance
+
+Otimize o processamento com paralelismo, rate limiting e tracking de tokens.
+
+## Processamento Paralelo
+
+Use `parallel_requests` para acelerar o processamento:
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    parallel_requests=5  # 5 requisições simultâneas
+)
+```
+
+### Recomendações por Tamanho
+
+| Dataset | Configuração |
+|---------|--------------|
+| < 50 linhas | `parallel_requests=1` (padrão) |
+| 50-500 linhas | `parallel_requests=3` a `5` |
+| > 500 linhas | `parallel_requests=5` a `10` |
+
+### Auto-redução em Rate Limits
+
+Quando detecta erro 429, o DataFrameIt reduz workers automaticamente:
+
+```
+Início: 10 workers
+Rate limit detectado → 5 workers
+Rate limit detectado → 2 workers
+Rate limit detectado → 1 worker
+```
+
+!!! info "Segurança"
+    Workers são apenas **reduzidos**, nunca aumentados automaticamente. Isso evita custos inesperados.
+
+## Rate Limiting
+
+Use `rate_limit_delay` para prevenir erros de rate limit:
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    rate_limit_delay=1.0  # 1 segundo entre requisições
+)
+```
+
+### Calculando o Delay Ideal
+
+```
+delay = 60 / requisições_por_minuto
+
+Exemplos:
+- 60 req/min  → delay = 1.0s
+- 500 req/min → delay = 0.12s
+- 50 req/min  → delay = 1.2s
+```
+
+### Por Provider
+
+| Provider | Free Tier | Delay Recomendado |
+|----------|-----------|-------------------|
+| Google Gemini | 60 req/min | 1.0s |
+| OpenAI (Tier 1) | 500 req/min | 0.15s |
+| Anthropic (Free) | 50 req/min | 1.2s |
+
+### Combinando com Paralelismo
+
+```python
+# 5 workers + delay entre requisições
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    parallel_requests=5,
+    rate_limit_delay=0.5
+)
+```
+
+## Tracking de Tokens
+
+Monitore uso e custos com `track_tokens=True`:
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    track_tokens=True
+)
+
+# Ao final, exibe:
+# ============================================================
+# ESTATÍSTICAS DE USO DE TOKENS
+# ============================================================
+# Modelo: gemini-2.0-flash
+# Total de tokens: 15,432
+#   • Input:  12,345 tokens
+#   • Output: 3,087 tokens
+# ============================================================
+```
+
+### Colunas Adicionadas
+
+| Coluna | Descrição |
+|--------|-----------|
+| `_input_tokens` | Tokens de entrada por linha |
+| `_output_tokens` | Tokens de saída por linha |
+| `_total_tokens` | Total por linha |
+
+### Calculando Custos
+
+```python
+resultado = dataframeit(df, Model, PROMPT, track_tokens=True)
+
+# Exemplo: preços Gemini 2.0 Flash
+preco_input = 0.075 / 1_000_000   # $0.075 por 1M tokens
+preco_output = 0.30 / 1_000_000   # $0.30 por 1M tokens
+
+custo_input = resultado['_input_tokens'].sum() * preco_input
+custo_output = resultado['_output_tokens'].sum() * preco_output
+custo_total = custo_input + custo_output
+
+print(f"Custo estimado: ${custo_total:.4f}")
+```
+
+## Métricas de Throughput
+
+O DataFrameIt exibe métricas automaticamente:
+
+```
+============================================================
+MÉTRICAS DE THROUGHPUT
+============================================================
+Tempo total: 45.2s
+Workers paralelos: 5
+Requisições: 100
+  - RPM (req/min): 132.7
+  - TPM (tokens/min): 20,478
+============================================================
+```
+
+Use essas métricas para calibrar `parallel_requests` para sua conta.
+
+## Configuração Otimizada
+
+### Para Máxima Velocidade
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    parallel_requests=10,     # Muitos workers
+    rate_limit_delay=0.0,     # Sem delay
+    max_retries=5,            # Retry agressivo
+    track_tokens=True
+)
+```
+
+### Para Estabilidade
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    parallel_requests=3,      # Poucos workers
+    rate_limit_delay=1.0,     # Delay conservador
+    max_retries=3,
+    base_delay=2.0,
+    track_tokens=True
+)
+```
+
+### Para Economia
+
+```python
+resultado = dataframeit(
+    df,
+    Model,
+    PROMPT,
+    parallel_requests=1,      # Sequencial
+    rate_limit_delay=1.5,     # Delay alto
+    model='gemini-2.0-flash', # Modelo barato
+    track_tokens=True
+)
+```

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -1,0 +1,186 @@
+# Provedores
+
+Configure diferentes provedores de LLM via LangChain.
+
+## Providers Suportados
+
+| Provider | Identificador | Modelos Populares |
+|----------|---------------|-------------------|
+| Google | `google_genai` | gemini-2.0-flash, gemini-1.5-pro |
+| OpenAI | `openai` | gpt-4o, gpt-4o-mini, o1, o3-mini |
+| Anthropic | `anthropic` | claude-3-5-sonnet, claude-3-opus |
+| Cohere | `cohere` | command-r, command-r-plus |
+| Mistral | `mistral` | mistral-large, mistral-small |
+
+## Google Gemini (Padrão)
+
+```bash
+pip install dataframeit[google]
+export GOOGLE_API_KEY="sua-chave"
+```
+
+```python
+# Padrão - não precisa especificar
+resultado = dataframeit(df, Model, PROMPT)
+
+# Explícito
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='google_genai',
+    model='gemini-2.0-flash'
+)
+
+# Com parâmetros extras
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='google_genai',
+    model='gemini-1.5-pro',
+    model_kwargs={
+        'temperature': 0.2,
+        'top_p': 0.9
+    }
+)
+```
+
+### Modelos Recomendados
+
+| Modelo | Uso | Custo |
+|--------|-----|-------|
+| `gemini-2.0-flash` | Uso geral, rápido | Baixo |
+| `gemini-1.5-flash` | Uso geral, estável | Baixo |
+| `gemini-1.5-pro` | Tarefas complexas | Médio |
+
+## OpenAI
+
+```bash
+pip install dataframeit[openai]
+export OPENAI_API_KEY="sua-chave"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# Com reasoning (modelos o1, o3)
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='o3-mini',
+    model_kwargs={
+        'reasoning_effort': 'medium'  # 'low', 'medium', 'high'
+    }
+)
+```
+
+### Modelos Recomendados
+
+| Modelo | Uso | Custo |
+|--------|-----|-------|
+| `gpt-4o-mini` | Uso geral, econômico | Baixo |
+| `gpt-4o` | Alta qualidade | Alto |
+| `o3-mini` | Reasoning, problemas complexos | Médio |
+
+## Anthropic Claude
+
+```bash
+pip install dataframeit[anthropic]
+export ANTHROPIC_API_KEY="sua-chave"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+
+# Com max_tokens
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022',
+    model_kwargs={
+        'max_tokens': 4096
+    }
+)
+```
+
+### Modelos Recomendados
+
+| Modelo | Uso | Custo |
+|--------|-----|-------|
+| `claude-3-5-sonnet-20241022` | Uso geral, excelente qualidade | Médio |
+| `claude-3-opus-20240229` | Máxima qualidade | Alto |
+| `claude-3-haiku-20240307` | Rápido, econômico | Baixo |
+
+## Cohere
+
+```bash
+pip install langchain-cohere
+export COHERE_API_KEY="sua-chave"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='cohere',
+    model='command-r-plus'
+)
+```
+
+## Mistral
+
+```bash
+pip install langchain-mistralai
+export MISTRAL_API_KEY="sua-chave"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='mistral',
+    model='mistral-large-latest'
+)
+```
+
+## Comparação de Preços (Aproximado)
+
+| Provider | Modelo | Input (1M tokens) | Output (1M tokens) |
+|----------|--------|-------------------|-------------------|
+| Google | gemini-2.0-flash | $0.075 | $0.30 |
+| Google | gemini-1.5-pro | $1.25 | $5.00 |
+| OpenAI | gpt-4o-mini | $0.15 | $0.60 |
+| OpenAI | gpt-4o | $2.50 | $10.00 |
+| Anthropic | claude-3-5-sonnet | $3.00 | $15.00 |
+| Anthropic | claude-3-haiku | $0.25 | $1.25 |
+
+!!! note "Preços mudam"
+    Verifique os preços atuais nos sites oficiais dos providers.
+
+## Passando API Key Diretamente
+
+Se preferir não usar variáveis de ambiente:
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='gpt-4o-mini',
+    api_key='sk-...'  # Sua chave diretamente
+)
+```
+
+!!! warning "Segurança"
+    Evite colocar API keys diretamente no código. Prefira variáveis de ambiente.
+
+## Parâmetros Comuns (model_kwargs)
+
+| Parâmetro | Descrição | Providers |
+|-----------|-----------|-----------|
+| `temperature` | Criatividade (0-1) | Todos |
+| `top_p` | Nucleus sampling | Todos |
+| `max_tokens` | Limite de saída | Todos |
+| `reasoning_effort` | Esforço de reasoning | OpenAI (o1, o3) |

--- a/docs/guides/structured-output.md
+++ b/docs/guides/structured-output.md
@@ -1,0 +1,174 @@
+# Saída Estruturada
+
+Aprenda a criar modelos Pydantic avançados para extrações complexas.
+
+## Tipos de Campos
+
+### Campos Obrigatórios
+
+```python
+from pydantic import BaseModel, Field
+
+class Modelo(BaseModel):
+    # Obrigatório sem default
+    titulo: str = Field(description="Título do documento")
+
+    # Obrigatório com validação
+    nota: int = Field(ge=1, le=10, description="Nota de 1 a 10")
+```
+
+### Campos Opcionais
+
+```python
+from typing import Optional
+
+class Modelo(BaseModel):
+    # Opcional - pode ser None
+    observacao: Optional[str] = Field(
+        default=None,
+        description="Observações adicionais, se houver"
+    )
+```
+
+### Campos com Valores Fixos (Literal)
+
+```python
+from typing import Literal
+
+class Modelo(BaseModel):
+    # Só aceita esses valores
+    prioridade: Literal['baixa', 'media', 'alta', 'critica']
+
+    # Múltiplas opções
+    status: Literal['pendente', 'em_andamento', 'concluido', 'cancelado']
+```
+
+!!! tip "Quando usar Literal"
+    Use `Literal` sempre que os valores possíveis são conhecidos e finitos. Isso:
+
+    - Força o LLM a escolher entre opções válidas
+    - Evita variações indesejadas (ex: "Alto" vs "alta" vs "ALTA")
+    - Facilita análises posteriores
+
+### Listas
+
+```python
+from typing import List
+
+class Modelo(BaseModel):
+    # Lista de strings
+    tags: List[str] = Field(description="Tags relevantes")
+
+    # Lista de objetos
+    itens: List[Item] = Field(description="Lista de itens extraídos")
+```
+
+## Modelos Aninhados
+
+Para estruturas complexas, use modelos aninhados:
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Literal
+
+class Endereco(BaseModel):
+    rua: str
+    cidade: str
+    estado: str
+    cep: Optional[str] = None
+
+class Contato(BaseModel):
+    nome: str
+    email: Optional[str] = None
+    telefone: Optional[str] = None
+    endereco: Optional[Endereco] = None
+
+class Empresa(BaseModel):
+    nome: str
+    cnpj: Optional[str] = None
+    contatos: List[Contato] = Field(description="Lista de contatos da empresa")
+    setor: Literal['tecnologia', 'saude', 'financas', 'varejo', 'outro']
+```
+
+## Exemplo Real: Análise Jurídica
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Literal, Tuple
+
+class Parte(BaseModel):
+    """Parte envolvida no processo."""
+    nome: str = Field(description="Nome completo da parte")
+    tipo: Literal['autor', 'reu', 'terceiro'] = Field(description="Tipo da parte")
+    cpf_cnpj: Optional[str] = Field(default=None, description="CPF ou CNPJ")
+
+class Pedido(BaseModel):
+    """Pedido feito no processo."""
+    descricao: str = Field(description="Descrição do pedido")
+    valor: Optional[float] = Field(default=None, description="Valor em reais")
+    deferido: Optional[bool] = Field(default=None, description="Se foi deferido")
+
+class DecisaoJudicial(BaseModel):
+    """Análise completa de uma decisão judicial."""
+
+    # Identificação
+    numero_processo: str = Field(description="Número do processo")
+    tribunal: str = Field(description="Tribunal (ex: TJSP, STF)")
+    data_decisao: str = Field(description="Data da decisão (YYYY-MM-DD)")
+
+    # Partes
+    partes: List[Parte] = Field(description="Partes envolvidas")
+
+    # Mérito
+    tipo_decisao: Literal['sentenca', 'acordao', 'despacho', 'decisao_interlocutoria']
+    resultado: Literal['procedente', 'improcedente', 'parcialmente_procedente', 'extinto']
+
+    # Pedidos
+    pedidos: List[Pedido] = Field(description="Pedidos analisados")
+
+    # Resumo
+    resumo: str = Field(description="Resumo da decisão em até 100 palavras")
+    fundamentos: List[str] = Field(description="Principais fundamentos jurídicos")
+
+PROMPT = """
+Analise a decisão judicial abaixo e extraia todas as informações relevantes.
+Seja preciso com datas, valores e nomes.
+Se alguma informação não estiver disponível, use null.
+"""
+
+resultado = dataframeit(df_decisoes, DecisaoJudicial, PROMPT)
+```
+
+## Validações Customizadas
+
+```python
+from pydantic import BaseModel, Field, field_validator
+
+class Documento(BaseModel):
+    cpf: str = Field(description="CPF no formato XXX.XXX.XXX-XX")
+    email: str = Field(description="Email válido")
+
+    @field_validator('cpf')
+    @classmethod
+    def validar_cpf(cls, v):
+        # Remove caracteres não numéricos
+        numeros = ''.join(filter(str.isdigit, v))
+        if len(numeros) != 11:
+            raise ValueError('CPF deve ter 11 dígitos')
+        return v
+```
+
+!!! warning "Cuidado com validações"
+    Validações muito restritivas podem causar erros frequentes. Use com moderação.
+
+## Boas Práticas
+
+1. **Use descrições claras**: O LLM usa as descrições para entender o que extrair
+
+2. **Prefira Literal a str**: Quando os valores são conhecidos, use `Literal`
+
+3. **Use Optional para campos incertos**: Se a informação pode não existir, marque como `Optional`
+
+4. **Quebre modelos complexos**: Use modelos aninhados para melhor organização
+
+5. **Teste com exemplos**: Valide seu modelo com textos reais antes de processar tudo

--- a/docs/guides/web-search.md
+++ b/docs/guides/web-search.md
@@ -1,0 +1,164 @@
+# Busca Web
+
+Enriqueça seus dados com busca web usando Tavily.
+
+## Visão Geral
+
+O DataFrameIt pode buscar informações na web para complementar a análise de cada texto. Isso é útil quando você precisa de contexto adicional que não está no texto original.
+
+## Configuração
+
+### 1. Instale a Dependência
+
+```bash
+pip install dataframeit[search]
+# ou
+pip install langchain-tavily
+```
+
+### 2. Configure a API Key
+
+```bash
+export TAVILY_API_KEY="sua-chave-tavily"
+```
+
+Obtenha sua chave em: [Tavily](https://tavily.com/)
+
+## Uso Básico
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class EmpresaInfo(BaseModel):
+    setor: Literal['tecnologia', 'saude', 'financas', 'varejo', 'outro']
+    descricao: str = Field(description="Breve descrição da empresa")
+    fundacao: str = Field(description="Ano de fundação, se encontrado")
+
+# Dados com nomes de empresas
+df = pd.DataFrame({
+    'texto': ['Microsoft', 'Nubank', 'iFood']
+})
+
+PROMPT = """
+Com base nas informações disponíveis e na busca web,
+extraia informações sobre a empresa mencionada.
+"""
+
+# Habilita busca web com use_search=True
+resultado = dataframeit(
+    df,
+    EmpresaInfo,
+    PROMPT,
+    use_search=True,      # Habilita busca web
+    max_results=5         # Número de resultados por busca
+)
+```
+
+## Parâmetros de Busca
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `use_search` | bool | `False` | Habilita busca web via Tavily |
+| `search_per_field` | bool | `False` | Executa busca separada para cada campo do modelo |
+| `max_results` | int | `5` | Resultados por busca (1-20) |
+| `search_depth` | str | `'basic'` | `'basic'` (1 crédito) ou `'advanced'` (2 créditos) |
+
+## Exemplos
+
+### Busca Básica
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    use_search=True
+)
+```
+
+### Busca por Campo
+
+Quando o modelo tem muitos campos, pode ser útil fazer buscas separadas:
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    use_search=True,
+    search_per_field=True  # Uma busca por campo do modelo
+)
+```
+
+### Busca Profunda
+
+```python
+# Busca mais detalhada (mais lenta, mais cara)
+resultado = dataframeit(
+    df, Model, PROMPT,
+    use_search=True,
+    search_depth='advanced',
+    max_results=10
+)
+```
+
+## Caso de Uso: Verificação de Fatos
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List
+
+class VerificacaoFato(BaseModel):
+    afirmacao: str = Field(description="A afirmação original")
+    veredicto: Literal['verdadeiro', 'falso', 'parcialmente_verdadeiro', 'inconclusivo']
+    fontes: List[str] = Field(description="Fontes que suportam o veredicto")
+    explicacao: str = Field(description="Explicação do veredicto")
+
+PROMPT = """
+Verifique a veracidade da afirmação usando as informações da busca web.
+Cite as fontes encontradas.
+"""
+
+resultado = dataframeit(
+    df_afirmacoes,
+    VerificacaoFato,
+    PROMPT,
+    use_search=True,
+    max_results=5,
+    search_depth='advanced'
+)
+```
+
+## Caso de Uso: Enriquecimento de Leads
+
+```python
+class LeadEnriquecido(BaseModel):
+    empresa: str
+    site: str = Field(description="Website oficial")
+    linkedin: str = Field(description="URL do LinkedIn")
+    tamanho: Literal['startup', 'pme', 'grande_empresa']
+    tecnologias: List[str] = Field(description="Tecnologias utilizadas")
+
+resultado = dataframeit(
+    df_leads,
+    LeadEnriquecido,
+    "Pesquise informações sobre a empresa.",
+    use_search=True,
+    max_results=3
+)
+```
+
+## Custos e Limites
+
+!!! warning "Atenção aos custos"
+    Cada linha do DataFrame faz uma busca web. Para datasets grandes, isso pode gerar custos significativos na API do Tavily.
+
+- **Free tier**: 1000 buscas/mês
+- **Busca básica**: ~$0.01 por busca
+- **Busca avançada**: ~$0.02 por busca
+
+### Dicas para Economizar
+
+1. Use `max_results=3` a `5` (suficiente para maioria dos casos)
+2. Prefira `search_depth='basic'`
+3. Filtre seu DataFrame antes de processar
+4. Use `search_per_field=False` quando possível

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,91 @@
+# DataFrameIt
+
+**Enriqueça DataFrames com LLMs de forma simples e estruturada.**
+
+DataFrameIt é uma biblioteca Python que permite processar textos em DataFrames e extrair informações estruturadas usando Modelos de Linguagem (LLMs). Defina o que você quer extrair com Pydantic, e a biblioteca cuida do resto.
+
+## Por que usar?
+
+- **Simples**: Uma função, um modelo Pydantic, um prompt. Pronto.
+- **Estruturado**: Saídas validadas automaticamente com Pydantic
+- **Resiliente**: Retry automático, rate limiting, processamento paralelo
+- **Flexível**: Suporta Gemini, OpenAI, Anthropic, Cohere, Mistral e mais
+
+## Instalação Rápida
+
+```bash
+pip install dataframeit[google]  # Para usar Google Gemini (recomendado)
+```
+
+## Exemplo em 30 Segundos
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Defina o que você quer extrair
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+    confianca: Literal['alta', 'media', 'baixa']
+
+# 2. Seus dados
+df = pd.DataFrame({
+    'texto': [
+        'Produto excelente! Superou expectativas.',
+        'Péssimo atendimento, nunca mais compro.',
+        'Entrega ok, produto mediano.'
+    ]
+})
+
+# 3. Processe!
+resultado = dataframeit(df, Sentimento, "Analise o sentimento do texto.")
+print(resultado)
+```
+
+**Saída:**
+
+| texto | sentimento | confianca |
+|-------|------------|-----------|
+| Produto excelente! Superou expectativas. | positivo | alta |
+| Péssimo atendimento, nunca mais compro. | negativo | alta |
+| Entrega ok, produto mediano. | neutro | media |
+
+## Próximos Passos
+
+<div class="grid cards" markdown>
+
+-   :material-download:{ .lg .middle } **Instalação**
+
+    ---
+
+    Configure a biblioteca com seu provider preferido
+
+    [:octicons-arrow-right-24: Guia de instalação](getting-started/installation.md)
+
+-   :material-rocket-launch:{ .lg .middle } **Início Rápido**
+
+    ---
+
+    Crie seu primeiro projeto em 5 minutos
+
+    [:octicons-arrow-right-24: Quickstart](getting-started/quickstart.md)
+
+-   :material-book-open-variant:{ .lg .middle } **Guias**
+
+    ---
+
+    Aprenda recursos avançados como paralelismo e retry
+
+    [:octicons-arrow-right-24: Ver guias](guides/basic-usage.md)
+
+-   :material-robot:{ .lg .middle } **Referência para LLMs**
+
+    ---
+
+    Documentação compacta otimizada para assistentes de código
+
+    [:octicons-arrow-right-24: LLM Reference](reference/llm-reference.md)
+
+</div>

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,209 @@
+# Referência da API
+
+Documentação completa de todas as funções e classes públicas.
+
+## dataframeit()
+
+Função principal para processar textos com LLMs.
+
+```python
+def dataframeit(
+    data,
+    questions,
+    prompt,
+    resume=True,
+    reprocess_columns=None,
+    model='gemini-3.0-flash',
+    provider='google_genai',
+    status_column=None,
+    text_column=None,
+    api_key=None,
+    max_retries=3,
+    base_delay=1.0,
+    max_delay=30.0,
+    rate_limit_delay=0.0,
+    track_tokens=True,
+    model_kwargs=None,
+    parallel_requests=1,
+    # Parâmetros de busca web
+    use_search=False,
+    search_per_field=False,
+    max_results=5,
+    search_depth="basic",
+) -> Any
+```
+
+### Parâmetros
+
+#### Dados
+
+| Parâmetro | Tipo | Obrigatório | Descrição |
+|-----------|------|-------------|-----------|
+| `data` | DataFrame, Series, list, dict | Sim | Dados contendo os textos a processar |
+| `questions` | Pydantic BaseModel | Sim | Modelo Pydantic definindo campos a extrair |
+| `prompt` | str | Sim | Template do prompt. Use `{texto}` para posicionar o texto |
+| `text_column` | str | DataFrame: Sim | Nome da coluna com textos. Padrão: `'texto'` |
+
+#### Processamento
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `resume` | bool | `True` | Continua de onde parou (pula linhas já processadas) |
+| `reprocess_columns` | list | `None` | Lista de colunas para forçar reprocessamento |
+| `status_column` | str | `None` | Nome customizado para coluna de status |
+
+#### Modelo
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `model` | str | `'gemini-3.0-flash'` | Nome do modelo LLM |
+| `provider` | str | `'google_genai'` | Provider LangChain |
+| `api_key` | str | `None` | API key (usa env var se None) |
+| `model_kwargs` | dict | `None` | Parâmetros extras (temperature, etc.) |
+
+#### Resiliência
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `max_retries` | int | `3` | Máximo de tentativas por linha |
+| `base_delay` | float | `1.0` | Delay inicial para retry (segundos) |
+| `max_delay` | float | `30.0` | Delay máximo para retry (segundos) |
+| `rate_limit_delay` | float | `0.0` | Delay entre requisições (segundos) |
+
+#### Performance
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `parallel_requests` | int | `1` | Workers paralelos (1 = sequencial) |
+| `track_tokens` | bool | `True` | Rastreia uso de tokens |
+
+#### Busca Web
+
+| Parâmetro | Tipo | Padrão | Descrição |
+|-----------|------|--------|-----------|
+| `use_search` | bool | `False` | Habilita busca web via Tavily |
+| `search_per_field` | bool | `False` | Executa busca separada por campo |
+| `max_results` | int | `5` | Resultados por busca (1-20) |
+| `search_depth` | str | `'basic'` | `'basic'` ou `'advanced'` |
+
+### Retorno
+
+Retorna dados no mesmo formato da entrada com colunas extraídas adicionadas.
+
+| Entrada | Saída |
+|---------|-------|
+| `pd.DataFrame` | `pd.DataFrame` com colunas do modelo Pydantic |
+| `pl.DataFrame` | `pl.DataFrame` com colunas do modelo Pydantic |
+| `pd.Series` | `pd.DataFrame` preservando índice |
+| `pl.Series` | `pl.DataFrame` |
+| `list` | `pd.DataFrame` com índice numérico |
+| `dict` | `pd.DataFrame` com chaves como índice |
+
+### Colunas Adicionadas
+
+| Coluna | Descrição |
+|--------|-----------|
+| `_dataframeit_status` | `'processed'`, `'error'`, ou `None` |
+| `_error_details` | Detalhes do erro (quando aplicável) |
+| `_input_tokens` | Tokens de entrada (se `track_tokens=True`) |
+| `_output_tokens` | Tokens de saída (se `track_tokens=True`) |
+| `_total_tokens` | Total de tokens (se `track_tokens=True`) |
+
+### Exemplos
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+import pandas as pd
+from dataframeit import dataframeit
+
+class Sentimento(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+
+df = pd.DataFrame({'texto': ['Ótimo!', 'Péssimo!']})
+
+# Básico
+resultado = dataframeit(df, Sentimento, "Analise o sentimento.")
+
+# Com configurações
+resultado = dataframeit(
+    df,
+    Sentimento,
+    "Analise o sentimento.",
+    provider='openai',
+    model='gpt-4o-mini',
+    parallel_requests=5,
+    rate_limit_delay=0.5,
+    max_retries=5
+)
+```
+
+---
+
+## read_df()
+
+Lê arquivos em diversos formatos para DataFrame.
+
+```python
+def read_df(path: str, **kwargs) -> pd.DataFrame
+```
+
+### Parâmetros
+
+| Parâmetro | Tipo | Descrição |
+|-----------|------|-----------|
+| `path` | str | Caminho do arquivo |
+| `**kwargs` | | Argumentos passados para pandas |
+
+### Formatos Suportados
+
+- `.xlsx`, `.xls` - Excel
+- `.csv` - CSV
+- `.json` - JSON
+- `.parquet` - Parquet
+
+### Exemplo
+
+```python
+from dataframeit import read_df
+
+df = read_df('dados.xlsx')
+df = read_df('dados.csv', encoding='utf-8')
+```
+
+---
+
+## normalize_value()
+
+Normaliza valores Python para tipos compatíveis com pandas.
+
+```python
+def normalize_value(value: Any) -> Any
+```
+
+Converte:
+- `tuple` → `list`
+- Objetos Pydantic → `dict`
+- Valores aninhados recursivamente
+
+---
+
+## normalize_complex_columns()
+
+Normaliza colunas com tipos complexos em um DataFrame.
+
+```python
+def normalize_complex_columns(df: pd.DataFrame, complex_fields: list) -> pd.DataFrame
+```
+
+---
+
+## get_complex_fields()
+
+Identifica campos complexos em um modelo Pydantic.
+
+```python
+def get_complex_fields(pydantic_model) -> list[str]
+```
+
+Retorna lista de nomes de campos que contêm `List`, `Tuple`, ou modelos aninhados.

--- a/docs/reference/llm-reference.md
+++ b/docs/reference/llm-reference.md
@@ -1,0 +1,257 @@
+# Referência para LLMs
+
+Esta página contém toda a informação necessária para usar DataFrameIt em uma única página compacta, otimizada para assistentes de código.
+
+---
+
+## O que é
+
+DataFrameIt processa textos em DataFrames usando LLMs e extrai informações estruturadas definidas por modelos Pydantic.
+
+## Instalação
+
+```bash
+pip install dataframeit[google]    # Google Gemini (padrão)
+pip install dataframeit[openai]    # OpenAI
+pip install dataframeit[anthropic] # Anthropic Claude
+```
+
+**Variáveis de ambiente:**
+```bash
+export GOOGLE_API_KEY="..."     # Para Gemini
+export OPENAI_API_KEY="..."     # Para OpenAI
+export ANTHROPIC_API_KEY="..."  # Para Anthropic
+```
+
+---
+
+## Assinatura da Função
+
+```python
+from dataframeit import dataframeit
+
+resultado = dataframeit(
+    data,                    # DataFrame, Series, list ou dict
+    questions,               # Modelo Pydantic
+    prompt,                  # Template do prompt
+    text_column='texto',     # Coluna com textos (obrigatório para DataFrame)
+    model='gemini-3.0-flash',
+    provider='google_genai', # 'google_genai', 'openai', 'anthropic'
+    resume=True,             # Continua de onde parou
+    parallel_requests=1,     # Workers paralelos
+    rate_limit_delay=0.0,    # Delay entre requisições (segundos)
+    max_retries=3,           # Tentativas em caso de erro
+    track_tokens=True,       # Rastreia uso de tokens
+    api_key=None,            # API key (usa env var se None)
+    model_kwargs=None,       # Parâmetros extras (temperature, etc)
+    # Busca web (requer TAVILY_API_KEY)
+    use_search=False,        # Habilita busca web
+    search_per_field=False,  # Busca separada por campo
+    max_results=5,           # Resultados por busca
+    search_depth='basic',    # 'basic' ou 'advanced'
+)
+```
+
+---
+
+## Exemplo Completo
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List, Optional
+import pandas as pd
+from dataframeit import dataframeit
+
+# 1. Definir modelo Pydantic
+class Analise(BaseModel):
+    sentimento: Literal['positivo', 'negativo', 'neutro']
+    confianca: Literal['alta', 'media', 'baixa']
+    temas: List[str] = Field(description="Temas principais")
+    resumo: str = Field(description="Resumo em uma frase")
+
+# 2. Dados
+df = pd.DataFrame({
+    'texto': [
+        'Produto excelente! Entrega rápida.',
+        'Péssimo atendimento, demorou muito.',
+        'Ok, nada de especial.'
+    ]
+})
+
+# 3. Processar
+resultado = dataframeit(
+    df,
+    Analise,
+    "Analise o texto e extraia as informações solicitadas."
+)
+
+# 4. Resultado contém colunas: texto, sentimento, confianca, temas, resumo
+print(resultado)
+```
+
+---
+
+## Tipos de Entrada Suportados
+
+```python
+# DataFrame (precisa text_column)
+df = pd.DataFrame({'texto': ['A', 'B']})
+resultado = dataframeit(df, Model, PROMPT)
+
+# Lista (não precisa text_column)
+textos = ['Texto 1', 'Texto 2']
+resultado = dataframeit(textos, Model, PROMPT)
+
+# Dicionário (chaves viram índice)
+docs = {'id1': 'Texto 1', 'id2': 'Texto 2'}
+resultado = dataframeit(docs, Model, PROMPT)
+
+# Series (preserva índice)
+series = pd.Series(['A', 'B'], index=['x', 'y'])
+resultado = dataframeit(series, Model, PROMPT)
+```
+
+---
+
+## Modelos Pydantic
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List, Optional
+
+# Campos com valores fixos
+class Exemplo(BaseModel):
+    categoria: Literal['A', 'B', 'C']
+
+# Campos opcionais
+class Exemplo(BaseModel):
+    nota: Optional[str] = Field(default=None, description="Observações")
+
+# Listas
+class Exemplo(BaseModel):
+    tags: List[str] = Field(description="Lista de tags")
+
+# Modelos aninhados
+class Endereco(BaseModel):
+    cidade: str
+    estado: str
+
+class Pessoa(BaseModel):
+    nome: str
+    endereco: Optional[Endereco] = None
+```
+
+---
+
+## Providers
+
+```python
+# Google Gemini (padrão)
+resultado = dataframeit(df, Model, PROMPT)
+
+# OpenAI
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='gpt-4o-mini'
+)
+
+# Anthropic
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='anthropic',
+    model='claude-3-5-sonnet-20241022'
+)
+
+# Com parâmetros extras
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='openai',
+    model='o3-mini',
+    model_kwargs={'reasoning_effort': 'medium'}
+)
+```
+
+---
+
+## Performance
+
+```python
+# Processamento paralelo
+resultado = dataframeit(
+    df, Model, PROMPT,
+    parallel_requests=5  # 5 workers simultâneos
+)
+
+# Rate limiting (previne erro 429)
+resultado = dataframeit(
+    df, Model, PROMPT,
+    rate_limit_delay=1.0  # 1 segundo entre requisições
+)
+
+# Combinados
+resultado = dataframeit(
+    df, Model, PROMPT,
+    parallel_requests=5,
+    rate_limit_delay=0.5
+)
+```
+
+---
+
+## Tratamento de Erros
+
+```python
+resultado = dataframeit(df, Model, PROMPT, max_retries=5)
+
+# Verificar erros
+erros = resultado[resultado['_dataframeit_status'] == 'error']
+print(erros['_error_details'])
+
+# Filtrar sucesso
+sucesso = resultado[resultado['_dataframeit_status'] == 'processed']
+```
+
+---
+
+## Colunas Adicionadas Automaticamente
+
+| Coluna | Descrição |
+|--------|-----------|
+| `_dataframeit_status` | `'processed'`, `'error'`, `None` |
+| `_error_details` | Mensagem de erro |
+| `_input_tokens` | Tokens de entrada |
+| `_output_tokens` | Tokens de saída |
+| `_total_tokens` | Total de tokens |
+
+---
+
+## Processamento Incremental
+
+```python
+# Processa e salva
+resultado = dataframeit(df, Model, PROMPT, resume=True)
+resultado.to_excel('parcial.xlsx', index=False)
+
+# Carrega e continua
+df = pd.read_excel('parcial.xlsx')
+resultado = dataframeit(df, Model, PROMPT, resume=True)
+```
+
+---
+
+## Prompt Template
+
+```python
+# Simples - texto adicionado ao final
+PROMPT = "Classifique o sentimento do texto."
+
+# Com placeholder - controle a posição
+PROMPT = """
+Analise o documento abaixo:
+
+{texto}
+
+Extraia as informações solicitadas.
+"""
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: DataFrameIt
+site_description: Enriqueça DataFrames com LLMs de forma simples e estruturada
+site_url: https://bdcdo.github.io/dataframeit
+repo_url: https://github.com/bdcdo/dataframeit
+repo_name: bdcdo/dataframeit
+
+theme:
+  name: material
+  language: pt-BR
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Modo escuro
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Modo claro
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search:
+      lang:
+        - pt
+        - en
+  - i18n:
+      docs_structure: folder
+      fallback_to_default: true
+      languages:
+        - locale: pt
+          default: true
+          name: Português
+          build: true
+        - locale: en
+          name: English
+          build: true
+          nav_translations:
+            Início: Home
+            Começando: Getting Started
+            Instalação: Installation
+            Início Rápido: Quickstart
+            Conceitos: Concepts
+            Guias: Guides
+            Uso Básico: Basic Usage
+            Saída Estruturada: Structured Output
+            Tratamento de Erros: Error Handling
+            Performance: Performance
+            Busca Web: Web Search
+            Provedores: Providers
+            Referência: Reference
+            API: API
+            Referência para LLMs: LLM Reference
+            Exemplos: Examples
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Início: index.md
+  - Começando:
+    - Instalação: getting-started/installation.md
+    - Início Rápido: getting-started/quickstart.md
+    - Conceitos: getting-started/concepts.md
+  - Guias:
+    - Uso Básico: guides/basic-usage.md
+    - Saída Estruturada: guides/structured-output.md
+    - Tratamento de Erros: guides/error-handling.md
+    - Performance: guides/performance.md
+    - Busca Web: guides/web-search.md
+    - Provedores: guides/providers.md
+  - Referência:
+    - API: reference/api.md
+    - Referência para LLMs: reference/llm-reference.md
+  - Exemplos: examples/index.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/bdcdo/dataframeit
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/dataframeit/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,15 @@ dev = [
     "pytest-cov>=4.0",
     "ruff>=0.1.0",
 ]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocs-static-i18n>=1.2.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/bdcdo/dataframeit"
-Documentation = "https://github.com/bdcdo/dataframeit#readme"
+Documentation = "https://bdcdo.github.io/dataframeit"
 Repository = "https://github.com/bdcdo/dataframeit.git"
 Issues = "https://github.com/bdcdo/dataframeit/issues"
 Changelog = "https://github.com/bdcdo/dataframeit/releases"


### PR DESCRIPTION
## Summary

- Add complete documentation structure in Portuguese and English
- MkDocs with Material theme and i18n support
- GitHub Actions workflow for automatic deployment to GitHub Pages
- Simplify README to point to full documentation

## Documentation Structure

- **Getting Started**: installation, quickstart, concepts
- **Guides**: basic usage, structured output, error handling, performance, web search, providers
- **Reference**: full API docs and compact LLM-optimized reference page
- **Examples**: index linking to Jupyter notebooks

## Special: LLM Reference Page

Created a compact reference page (`/reference/llm-reference/`) optimized for code assistants like Claude Code - contains all essential information in a single page for easy WebFetch.

## Test plan

- [x] `mkdocs build` runs without errors
- [ ] Verify documentation renders correctly after merge
- [ ] Check both PT and EN versions
- [ ] Test language switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)