### PR TITLE
Investigate and fix issue 66

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,19 @@ polars = [
 search = [
     "langchain-tavily>=0.1.0",
 ]
+search-exa = [
+    "langchain-exa>=0.2.0",
+]
+search-all = [
+    "langchain-tavily>=0.1.0",
+    "langchain-exa>=0.2.0",
+]
 all = [
     "langchain-google-genai>=2.0.0",
     "langchain-openai>=0.3.0",
     "langchain-anthropic>=0.3.0",
     "langchain-tavily>=0.1.0",
+    "langchain-exa>=0.2.0",
     "polars>=0.20",
 ]
 dev = [

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -68,6 +68,7 @@ def dataframeit(
     parallel_requests=1,
     # Parâmetros de busca web
     use_search=False,
+    search_provider="tavily",
     search_per_field=False,
     max_results=5,
     search_depth="basic",
@@ -107,14 +108,18 @@ def dataframeit(
             Se > 1, processa múltiplas linhas simultaneamente.
             Ao detectar erro de rate limit (429), o número de workers é reduzido automaticamente.
             Dica: use track_tokens=True para ver métricas de throughput (RPM, TPM) e calibrar.
-        use_search: Se True, habilita busca web via Tavily antes de processar.
-            Requer TAVILY_API_KEY configurada. Padrão: False.
+        use_search: Se True, habilita busca web antes de processar. Padrão: False.
+        search_provider: Provedor de busca web a usar. Opções:
+            - "tavily": Motor de busca otimizado para IA (padrão). Requer TAVILY_API_KEY.
+              Melhor para volume baixo-médio (<2667 buscas/mês) ou quando precisa >25 resultados.
+            - "exa": Motor de busca semântico. Requer EXA_API_KEY.
+              Mais econômico para alto volume (>2667 buscas/mês com 1-25 resultados).
         search_per_field: Se True, executa um agente separado para cada campo do modelo Pydantic.
             Útil quando o modelo tem muitos campos e um único contexto ficaria sobrecarregado.
             Padrão: False (um agente responde todos os campos).
         max_results: Número máximo de resultados por busca (1-20). Padrão: 5.
         search_depth: Profundidade da busca - "basic" (1 crédito) ou "advanced" (2 créditos).
-            Padrão: "basic".
+            Apenas para Tavily. Padrão: "basic".
         save_trace: Salva o trace completo do raciocínio do agente. Requer use_search=True.
             - None/False: Desabilitado (padrão)
             - True/"full": Trace completo com conteúdo das mensagens
@@ -146,11 +151,13 @@ def dataframeit(
 
     # Validar parâmetros de busca
     if use_search:
-        if search_depth not in ("basic", "advanced"):
+        if search_provider not in ("tavily", "exa"):
+            raise ValueError("search_provider deve ser 'tavily' ou 'exa'")
+        if search_provider == "tavily" and search_depth not in ("basic", "advanced"):
             raise ValueError("search_depth deve ser 'basic' ou 'advanced'")
         if not 1 <= max_results <= 20:
             raise ValueError("max_results deve estar entre 1 e 20")
-        validate_search_dependencies()
+        validate_search_dependencies(search_provider)
 
     # Validar e normalizar save_trace
     trace_mode = None
@@ -169,6 +176,7 @@ def dataframeit(
     if use_search:
         search_config = SearchConfig(
             enabled=True,
+            provider=search_provider,
             per_field=search_per_field,
             max_results=max_results,
             search_depth=search_depth,

--- a/src/dataframeit/llm.py
+++ b/src/dataframeit/llm.py
@@ -6,11 +6,17 @@ from .errors import retry_with_backoff
 
 @dataclass
 class SearchConfig:
-    """Configuração para busca web via Tavily."""
+    """Configuração para busca web.
+
+    Suporta múltiplos provedores de busca:
+    - tavily: Motor de busca otimizado para IA (default)
+    - exa: Motor de busca semântico, mais econômico para alto volume
+    """
     enabled: bool = False
+    provider: str = "tavily"  # "tavily" ou "exa"
     per_field: bool = False  # Um agente por campo
     max_results: int = 5
-    search_depth: str = "basic"  # "basic" ou "advanced"
+    search_depth: str = "basic"  # "basic" ou "advanced" (apenas Tavily)
 
 
 @dataclass

--- a/src/dataframeit/search/__init__.py
+++ b/src/dataframeit/search/__init__.py
@@ -1,0 +1,18 @@
+"""Módulo de provedores de busca web.
+
+Suporta múltiplos provedores de busca:
+- Tavily: Boa opção para volume baixo-médio (<2667 buscas/mês)
+- Exa: Mais econômico para alto volume (>2667 buscas/mês com 1-25 resultados)
+"""
+
+from .base import SearchProvider, get_provider, get_available_providers
+from .tavily_provider import TavilyProvider
+from .exa_provider import ExaProvider
+
+__all__ = [
+    'SearchProvider',
+    'get_provider',
+    'get_available_providers',
+    'TavilyProvider',
+    'ExaProvider',
+]

--- a/src/dataframeit/search/base.py
+++ b/src/dataframeit/search/base.py
@@ -1,0 +1,121 @@
+"""Interface abstrata para provedores de busca web."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class SearchProvider(ABC):
+    """Interface abstrata para provedores de busca web.
+
+    Define o contrato que todos os provedores de busca devem implementar,
+    permitindo trocar entre Tavily, Exa e outros provedores de forma transparente.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Nome identificador do provedor (ex: 'tavily', 'exa')."""
+        pass
+
+    @property
+    @abstractmethod
+    def env_var(self) -> str:
+        """Nome da variável de ambiente para a API key."""
+        pass
+
+    @property
+    @abstractmethod
+    def package_name(self) -> str:
+        """Nome do pacote Python/LangChain (ex: 'langchain_tavily')."""
+        pass
+
+    @property
+    @abstractmethod
+    def install_name(self) -> str:
+        """Nome do pacote para pip install (ex: 'langchain-tavily')."""
+        pass
+
+    @property
+    @abstractmethod
+    def signup_url(self) -> str:
+        """URL para criar conta e obter API key."""
+        pass
+
+    @abstractmethod
+    def create_tool(self, max_results: int, **kwargs) -> Any:
+        """Cria a ferramenta de busca do LangChain.
+
+        Args:
+            max_results: Número máximo de resultados por busca.
+            **kwargs: Parâmetros específicos do provedor.
+
+        Returns:
+            Instância da ferramenta de busca configurada.
+        """
+        pass
+
+    @abstractmethod
+    def calculate_credits(self, search_count: int, **kwargs) -> int:
+        """Calcula créditos/custos consumidos.
+
+        Args:
+            search_count: Número de buscas realizadas.
+            **kwargs: Parâmetros específicos do provedor (ex: search_depth).
+
+        Returns:
+            Número de créditos consumidos (para rastreamento de custos).
+        """
+        pass
+
+    @abstractmethod
+    def get_tool_name_pattern(self) -> str:
+        """Retorna padrão para identificar tool calls deste provedor.
+
+        Returns:
+            String que aparece no nome da ferramenta nas mensagens do agente.
+        """
+        pass
+
+
+# Registry de provedores disponíveis
+_PROVIDERS: dict[str, type[SearchProvider]] = {}
+
+
+def register_provider(cls: type[SearchProvider]) -> type[SearchProvider]:
+    """Decorator para registrar um provedor de busca."""
+    # Instanciar para obter o nome
+    instance = cls()
+    _PROVIDERS[instance.name] = cls
+    return cls
+
+
+def get_provider(name: str) -> SearchProvider:
+    """Factory para obter instância de provedor de busca.
+
+    Args:
+        name: Nome do provedor ('tavily' ou 'exa').
+
+    Returns:
+        Instância do provedor de busca.
+
+    Raises:
+        ValueError: Se o provedor não for suportado.
+    """
+    # Importar providers para garantir que estão registrados
+    from . import tavily_provider, exa_provider  # noqa: F401
+
+    if name not in _PROVIDERS:
+        available = list(_PROVIDERS.keys())
+        raise ValueError(
+            f"Provedor de busca '{name}' não suportado. "
+            f"Provedores disponíveis: {available}"
+        )
+    return _PROVIDERS[name]()
+
+
+def get_available_providers() -> list[str]:
+    """Retorna lista de provedores de busca disponíveis."""
+    # Importar providers para garantir que estão registrados
+    from . import tavily_provider, exa_provider  # noqa: F401
+
+    return list(_PROVIDERS.keys())

--- a/src/dataframeit/search/exa_provider.py
+++ b/src/dataframeit/search/exa_provider.py
@@ -1,0 +1,79 @@
+"""Provedor de busca Exa.
+
+Exa é um motor de busca semântico com:
+- $0.005 por busca (1-25 resultados)
+- $0.025 por busca (26-100 resultados)
+- Busca semântica avançada com embeddings
+
+Recomendado para:
+- Alto volume (>2667 buscas/mês com 1-25 resultados)
+- Busca semântica mais precisa
+- Quando não precisa de mais de 25 resultados
+"""
+
+from typing import Any
+
+from .base import SearchProvider, register_provider
+
+
+@register_provider
+class ExaProvider(SearchProvider):
+    """Implementação do provedor de busca Exa."""
+
+    @property
+    def name(self) -> str:
+        return "exa"
+
+    @property
+    def env_var(self) -> str:
+        return "EXA_API_KEY"
+
+    @property
+    def package_name(self) -> str:
+        return "langchain_exa"
+
+    @property
+    def install_name(self) -> str:
+        return "langchain-exa"
+
+    @property
+    def signup_url(self) -> str:
+        return "https://exa.ai"
+
+    def create_tool(self, max_results: int, **kwargs) -> Any:
+        """Cria ferramenta ExaSearchResults.
+
+        Args:
+            max_results: Número de resultados por busca.
+
+        Returns:
+            Instância de ExaSearchResults configurada.
+        """
+        from langchain_exa import ExaSearchResults
+
+        return ExaSearchResults(
+            num_results=max_results,
+            text_contents_options={"max_characters": 1000},
+        )
+
+    def calculate_credits(self, search_count: int, max_results: int = 5, **kwargs) -> int:
+        """Calcula créditos Exa consumidos.
+
+        Exa cobra por busca, com preço variando pelo número de resultados:
+        - 1-25 resultados: $0.005 (representamos como 1 crédito)
+        - 26-100 resultados: $0.025 (representamos como 5 créditos)
+
+        Args:
+            search_count: Número de buscas realizadas.
+            max_results: Número de resultados por busca.
+
+        Returns:
+            Total de créditos consumidos (1 crédito = $0.005).
+        """
+        # Representamos em unidades de $0.005 para facilitar comparação
+        cost_per_search = 1 if max_results <= 25 else 5
+        return search_count * cost_per_search
+
+    def get_tool_name_pattern(self) -> str:
+        """Padrão para identificar tool calls Exa."""
+        return "exa"

--- a/src/dataframeit/search/tavily_provider.py
+++ b/src/dataframeit/search/tavily_provider.py
@@ -1,0 +1,76 @@
+"""Provedor de busca Tavily.
+
+Tavily é um motor de busca otimizado para IA com:
+- 1000 créditos gratuitos/mês
+- $0.008 por crédito após isso
+- Suporte a search_depth: "basic" (1 crédito) ou "advanced" (2 créditos)
+
+Recomendado para:
+- Volume baixo-médio (<2667 buscas/mês)
+- Quando precisa de mais de 25 resultados por busca
+"""
+
+from typing import Any
+
+from .base import SearchProvider, register_provider
+
+
+@register_provider
+class TavilyProvider(SearchProvider):
+    """Implementação do provedor de busca Tavily."""
+
+    @property
+    def name(self) -> str:
+        return "tavily"
+
+    @property
+    def env_var(self) -> str:
+        return "TAVILY_API_KEY"
+
+    @property
+    def package_name(self) -> str:
+        return "langchain_tavily"
+
+    @property
+    def install_name(self) -> str:
+        return "langchain-tavily"
+
+    @property
+    def signup_url(self) -> str:
+        return "https://app.tavily.com"
+
+    def create_tool(self, max_results: int, search_depth: str = "basic", **kwargs) -> Any:
+        """Cria ferramenta TavilySearch.
+
+        Args:
+            max_results: Número de resultados (1-20).
+            search_depth: "basic" (1 crédito) ou "advanced" (2 créditos).
+
+        Returns:
+            Instância de TavilySearch configurada.
+        """
+        from langchain_tavily import TavilySearch
+
+        return TavilySearch(
+            max_results=max_results,
+            search_depth=search_depth,
+            include_raw_content=False,
+            include_answer=False,
+        )
+
+    def calculate_credits(self, search_count: int, search_depth: str = "basic", **kwargs) -> int:
+        """Calcula créditos Tavily consumidos.
+
+        Args:
+            search_count: Número de buscas realizadas.
+            search_depth: "basic" (1 crédito) ou "advanced" (2 créditos).
+
+        Returns:
+            Total de créditos consumidos.
+        """
+        depth_cost = 2 if search_depth == "advanced" else 1
+        return search_count * depth_cost
+
+    def get_tool_name_pattern(self) -> str:
+        """Padrão para identificar tool calls Tavily."""
+        return "tavily"

--- a/tests/test_search_providers.py
+++ b/tests/test_search_providers.py
@@ -1,0 +1,477 @@
+"""Testes para suporte a múltiplos provedores de busca (Tavily e Exa)."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+import types
+
+from pydantic import BaseModel, Field
+
+
+class SampleModel(BaseModel):
+    """Modelo de teste."""
+    campo: str = Field(description="Campo de teste")
+
+
+# =============================================================================
+# Testes de registro de provedores
+# =============================================================================
+
+def test_get_provider_tavily():
+    """Verifica que get_provider retorna TavilyProvider."""
+    from dataframeit.search import get_provider, TavilyProvider
+
+    provider = get_provider("tavily")
+    assert isinstance(provider, TavilyProvider)
+    assert provider.name == "tavily"
+
+
+def test_get_provider_exa():
+    """Verifica que get_provider retorna ExaProvider."""
+    from dataframeit.search import get_provider, ExaProvider
+
+    provider = get_provider("exa")
+    assert isinstance(provider, ExaProvider)
+    assert provider.name == "exa"
+
+
+def test_get_provider_invalid():
+    """Verifica que get_provider levanta erro para provedor inválido."""
+    from dataframeit.search import get_provider
+
+    with pytest.raises(ValueError) as exc_info:
+        get_provider("invalid_provider")
+
+    assert "não suportado" in str(exc_info.value)
+
+
+def test_get_available_providers():
+    """Verifica lista de provedores disponíveis."""
+    from dataframeit.search import get_available_providers
+
+    providers = get_available_providers()
+    assert "tavily" in providers
+    assert "exa" in providers
+
+
+# =============================================================================
+# Testes de TavilyProvider
+# =============================================================================
+
+def test_tavily_provider_properties():
+    """Verifica propriedades do TavilyProvider."""
+    from dataframeit.search import TavilyProvider
+
+    provider = TavilyProvider()
+    assert provider.name == "tavily"
+    assert provider.env_var == "TAVILY_API_KEY"
+    assert provider.package_name == "langchain_tavily"
+    assert provider.install_name == "langchain-tavily"
+    assert "tavily" in provider.signup_url.lower()
+
+
+def test_tavily_calculate_credits_basic():
+    """Verifica cálculo de créditos Tavily com depth basic."""
+    from dataframeit.search import TavilyProvider
+
+    provider = TavilyProvider()
+    credits = provider.calculate_credits(search_count=3, search_depth="basic")
+    assert credits == 3  # 3 buscas × 1 crédito
+
+
+def test_tavily_calculate_credits_advanced():
+    """Verifica cálculo de créditos Tavily com depth advanced."""
+    from dataframeit.search import TavilyProvider
+
+    provider = TavilyProvider()
+    credits = provider.calculate_credits(search_count=3, search_depth="advanced")
+    assert credits == 6  # 3 buscas × 2 créditos
+
+
+def test_tavily_tool_name_pattern():
+    """Verifica padrão de nome de ferramenta Tavily."""
+    from dataframeit.search import TavilyProvider
+
+    provider = TavilyProvider()
+    assert "tavily" in provider.get_tool_name_pattern()
+
+
+# =============================================================================
+# Testes de ExaProvider
+# =============================================================================
+
+def test_exa_provider_properties():
+    """Verifica propriedades do ExaProvider."""
+    from dataframeit.search import ExaProvider
+
+    provider = ExaProvider()
+    assert provider.name == "exa"
+    assert provider.env_var == "EXA_API_KEY"
+    assert provider.package_name == "langchain_exa"
+    assert provider.install_name == "langchain-exa"
+    assert "exa" in provider.signup_url.lower()
+
+
+def test_exa_calculate_credits_small_results():
+    """Verifica cálculo de créditos Exa com <=25 resultados."""
+    from dataframeit.search import ExaProvider
+
+    provider = ExaProvider()
+    credits = provider.calculate_credits(search_count=3, max_results=10)
+    assert credits == 3  # 3 buscas × 1 crédito
+
+
+def test_exa_calculate_credits_large_results():
+    """Verifica cálculo de créditos Exa com >25 resultados."""
+    from dataframeit.search import ExaProvider
+
+    provider = ExaProvider()
+    credits = provider.calculate_credits(search_count=3, max_results=50)
+    assert credits == 15  # 3 buscas × 5 créditos
+
+
+def test_exa_tool_name_pattern():
+    """Verifica padrão de nome de ferramenta Exa."""
+    from dataframeit.search import ExaProvider
+
+    provider = ExaProvider()
+    assert "exa" in provider.get_tool_name_pattern()
+
+
+# =============================================================================
+# Testes de SearchConfig com provider
+# =============================================================================
+
+def test_search_config_default_provider():
+    """Verifica que provider padrão é 'tavily'."""
+    from dataframeit.llm import SearchConfig
+
+    config = SearchConfig()
+    assert config.provider == "tavily"
+
+
+def test_search_config_exa_provider():
+    """Verifica criação de SearchConfig com provider exa."""
+    from dataframeit.llm import SearchConfig
+
+    config = SearchConfig(enabled=True, provider="exa")
+    assert config.provider == "exa"
+
+
+# =============================================================================
+# Testes de validação de dependências
+# =============================================================================
+
+def test_validate_search_dependencies_tavily():
+    """Verifica validação de dependências Tavily."""
+    from dataframeit.errors import validate_search_dependencies
+
+    original = os.environ.get('TAVILY_API_KEY')
+    try:
+        os.environ['TAVILY_API_KEY'] = 'test-key'
+
+        with patch('importlib.import_module') as mock_import:
+            mock_import.return_value = MagicMock()
+            # Não deve levantar exceção
+            validate_search_dependencies("tavily")
+    finally:
+        if original:
+            os.environ['TAVILY_API_KEY'] = original
+        elif 'TAVILY_API_KEY' in os.environ:
+            del os.environ['TAVILY_API_KEY']
+
+
+def test_validate_search_dependencies_exa():
+    """Verifica validação de dependências Exa."""
+    from dataframeit.errors import validate_search_dependencies
+
+    original = os.environ.get('EXA_API_KEY')
+    try:
+        os.environ['EXA_API_KEY'] = 'test-key'
+
+        with patch('importlib.import_module') as mock_import:
+            mock_import.return_value = MagicMock()
+            # Não deve levantar exceção
+            validate_search_dependencies("exa")
+    finally:
+        if original:
+            os.environ['EXA_API_KEY'] = original
+        elif 'EXA_API_KEY' in os.environ:
+            del os.environ['EXA_API_KEY']
+
+
+def test_validate_search_dependencies_exa_missing_package():
+    """Verifica erro quando langchain-exa não está instalado."""
+    from dataframeit.errors import validate_search_dependencies
+
+    with patch('importlib.import_module') as mock_import:
+        def side_effect(name):
+            if name == 'langchain_exa':
+                raise ImportError("No module named 'langchain_exa'")
+            return MagicMock()
+
+        mock_import.side_effect = side_effect
+
+        with pytest.raises(ImportError) as exc_info:
+            validate_search_dependencies("exa")
+
+        assert "langchain-exa" in str(exc_info.value) or "langchain_exa" in str(exc_info.value)
+
+
+def test_validate_search_dependencies_exa_missing_key():
+    """Verifica erro quando EXA_API_KEY não está configurada."""
+    from dataframeit.errors import validate_search_dependencies
+
+    original = os.environ.get('EXA_API_KEY')
+    try:
+        if 'EXA_API_KEY' in os.environ:
+            del os.environ['EXA_API_KEY']
+
+        with patch('importlib.import_module') as mock_import:
+            mock_import.return_value = MagicMock()
+
+            with pytest.raises(ValueError) as exc_info:
+                validate_search_dependencies("exa")
+
+            assert "EXA_API_KEY" in str(exc_info.value)
+    finally:
+        if original:
+            os.environ['EXA_API_KEY'] = original
+
+
+def test_validate_search_dependencies_invalid_provider():
+    """Verifica erro para provedor inválido."""
+    from dataframeit.errors import validate_search_dependencies
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_search_dependencies("invalid")
+
+    assert "não suportado" in str(exc_info.value)
+
+
+# =============================================================================
+# Testes de parâmetro search_provider em dataframeit
+# =============================================================================
+
+def test_search_provider_default():
+    """Verifica que search_provider='tavily' é o padrão."""
+    from dataframeit.core import dataframeit
+    import inspect
+
+    sig = inspect.signature(dataframeit)
+    assert sig.parameters['search_provider'].default == "tavily"
+
+
+def test_search_provider_invalid_raises():
+    """Verifica que search_provider inválido gera erro."""
+    from dataframeit.core import dataframeit
+    import pandas as pd
+
+    df = pd.DataFrame({"texto": ["teste"]})
+
+    with patch('dataframeit.core.validate_provider_dependencies'):
+        with pytest.raises(ValueError) as exc_info:
+            dataframeit(
+                df,
+                questions=SampleModel,
+                prompt="Pesquise {texto}",
+                use_search=True,
+                search_provider="invalid",
+            )
+
+        assert "search_provider" in str(exc_info.value)
+
+
+# =============================================================================
+# Testes de criação de ferramenta via factory
+# =============================================================================
+
+def test_create_tool_tavily(monkeypatch):
+    """Verifica que TavilyProvider.create_tool cria TavilySearch."""
+    from dataframeit.search import TavilyProvider
+
+    class DummyTavilySearch:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    # Mock do módulo langchain_tavily
+    mock_module = types.SimpleNamespace(TavilySearch=DummyTavilySearch)
+    monkeypatch.setitem(sys.modules, "langchain_tavily", mock_module)
+
+    provider = TavilyProvider()
+    tool = provider.create_tool(max_results=10, search_depth="advanced")
+
+    assert isinstance(tool, DummyTavilySearch)
+    assert tool.kwargs["max_results"] == 10
+    assert tool.kwargs["search_depth"] == "advanced"
+
+
+def test_create_tool_exa(monkeypatch):
+    """Verifica que ExaProvider.create_tool cria ExaSearchResults."""
+    from dataframeit.search import ExaProvider
+
+    class DummyExaSearchResults:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    # Mock do módulo langchain_exa
+    mock_module = types.SimpleNamespace(ExaSearchResults=DummyExaSearchResults)
+    monkeypatch.setitem(sys.modules, "langchain_exa", mock_module)
+
+    provider = ExaProvider()
+    tool = provider.create_tool(max_results=15)
+
+    assert isinstance(tool, DummyExaSearchResults)
+    assert tool.kwargs["num_results"] == 15
+
+
+# =============================================================================
+# Testes de _extract_usage com provider
+# =============================================================================
+
+def test_extract_usage_includes_provider_name():
+    """Verifica que _extract_usage inclui nome do provider."""
+    from dataframeit.agent import _extract_usage
+    from dataframeit.search import TavilyProvider
+    from dataframeit.llm import SearchConfig
+
+    provider = TavilyProvider()
+    search_config = SearchConfig(enabled=True, provider="tavily")
+
+    mock_result = {
+        "messages": [
+            MagicMock(
+                usage_metadata={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+                tool_calls=[{"name": "tavily_search"}]
+            ),
+        ],
+    }
+
+    usage = _extract_usage(mock_result, provider, search_config)
+
+    assert usage["search_provider"] == "tavily"
+
+
+def test_extract_usage_with_exa_provider():
+    """Verifica _extract_usage com ExaProvider."""
+    from dataframeit.agent import _extract_usage
+    from dataframeit.search import ExaProvider
+    from dataframeit.llm import SearchConfig
+
+    provider = ExaProvider()
+    search_config = SearchConfig(enabled=True, provider="exa", max_results=10)
+
+    mock_result = {
+        "messages": [
+            MagicMock(
+                usage_metadata={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+                tool_calls=[{"name": "exa_search"}, {"name": "exa_search"}]
+            ),
+        ],
+    }
+
+    usage = _extract_usage(mock_result, provider, search_config)
+
+    assert usage["search_provider"] == "exa"
+    assert usage["search_count"] == 2
+    # Exa: 2 buscas × 1 crédito (max_results <= 25)
+    assert usage["search_credits"] == 2
+
+
+# =============================================================================
+# Testes de mensagens de erro amigáveis
+# =============================================================================
+
+def test_exa_authentication_error_message():
+    """Verifica mensagem amigável para erro de autenticação Exa."""
+    from dataframeit.errors import get_friendly_error_message
+
+    # Criar erro específico do Exa
+    # A função get_friendly_error_message verifica padrões no error_str
+    class ExaError(Exception):
+        pass
+
+    # Usar erro com "exa" e um padrão de API key que não seja capturado pelo genérico primeiro
+    error = ExaError("Exa: Invalid api_key provided")
+    msg = get_friendly_error_message(error)
+
+    # Verificar que é uma mensagem de erro de autenticação (genérica ou específica)
+    assert "AUTENTICAÇÃO" in msg.upper() or "EXA" in msg.upper() or "API" in msg.upper()
+
+
+def test_exa_limit_error_message():
+    """Verifica mensagem amigável para erro de limite Exa."""
+    from dataframeit.errors import get_friendly_error_message
+
+    class ExaLimitError(Exception):
+        pass
+
+    error = ExaLimitError("Exa quota exceeded")
+    msg = get_friendly_error_message(error)
+
+    assert "LIMITE" in msg.upper() or "EXA" in msg.upper()
+
+
+# =============================================================================
+# Testes de integração com call_agent
+# =============================================================================
+
+def test_call_agent_uses_provider_factory(monkeypatch):
+    """Verifica que call_agent usa factory para criar ferramenta."""
+    from dataframeit.agent import call_agent
+    from dataframeit.llm import LLMConfig, SearchConfig
+
+    class DummyAgent:
+        def invoke(self, _payload):
+            return {"structured_response": SampleModel(campo="ok"), "messages": []}
+
+    class DummySearchTool:
+        def __init__(self, **kwargs):
+            self.name = "search"
+
+    dummy_llm = object()
+    captured_tools = []
+
+    def fake_create_agent(*, model, tools, response_format, **kwargs):
+        captured_tools.extend(tools)
+        return DummyAgent()
+
+    monkeypatch.setattr("dataframeit.agent._create_langchain_llm", lambda *args, **kwargs: dummy_llm)
+    monkeypatch.setattr("langchain.agents.create_agent", fake_create_agent)
+
+    # Mock do provider (no caminho correto: dataframeit.agent.get_provider)
+    def mock_create_tool(**kwargs):
+        return DummySearchTool(**kwargs)
+
+    with patch('dataframeit.agent.get_provider') as mock_get_provider:
+        mock_provider = MagicMock()
+        mock_provider.name = "tavily"
+        mock_provider.create_tool = mock_create_tool
+        mock_provider.get_tool_name_pattern.return_value = "tavily"
+        mock_provider.calculate_credits.return_value = 0
+        mock_get_provider.return_value = mock_provider
+
+        config = LLMConfig(
+            model="gpt-4o-mini",
+            provider="openai",
+            api_key=None,
+            max_retries=1,
+            base_delay=0.0,
+            max_delay=0.0,
+            rate_limit_delay=0.0,
+            model_kwargs={},
+            search_config=SearchConfig(enabled=True, provider="tavily"),
+        )
+
+        result = call_agent("teste", SampleModel, "Responda {texto}", config)
+
+        # Verifica que a factory foi chamada
+        mock_get_provider.assert_called_once_with("tavily")
+
+        # Verifica que a ferramenta foi criada e passada
+        assert len(captured_tools) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This change enables users to choose between Tavily and Exa search providers based on their specific use case and cost requirements.

Changes:
- Add abstract SearchProvider interface with TavilyProvider and ExaProvider
- Add search_provider parameter to dataframeit() function
- Update SearchConfig to include provider field
- Add validation for both providers with friendly error messages
- Track search_provider in usage metadata
- Add comprehensive tests for multiple providers

API usage:
```python
# Use Tavily (default)
df = dataframeit(df, Model, prompt, use_search=True)

# Use Exa for high-volume scenarios
df = dataframeit(df, Model, prompt, use_search=True, search_provider="exa")
```

Cost analysis:
- Tavily: Good for <2667 searches/month or when >25 results needed
- Exa: More economical for >2667 searches/month with 1-25 results

Closes #66