### PR TITLE
feat(search): add search_groups for grouped field searches (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [0.5.3] - 2025-01-19
+
+### Adicionado
+
+- **`search_groups` - Agrupamento de campos para busca compartilhada** (#77): Novo parâmetro que permite agrupar campos que compartilham contexto de busca, reduzindo chamadas de API redundantes.
+
+  ```python
+  result = dataframeit(
+      df, MyModel, PROMPT,
+      use_search=True,
+      search_per_field=True,
+      search_groups={
+          "regulatory": {
+              "fields": ["status_anvisa", "avaliacao_conitec", "existe_pcdt"],
+              "prompt": "Search regulatory status: ANVISA, CONITEC, PCDT for {query}",
+              "max_results": 5,
+              "search_depth": "advanced",  # opcional
+          }
+      }
+  )
+  ```
+
+  - **Redução de chamadas**: Campos em um grupo compartilham a mesma busca (1 busca para múltiplos campos)
+  - **Prompts customizados**: Cada grupo pode ter seu próprio prompt com `{query}` placeholder
+  - **Parâmetros por grupo**: `max_results` e `search_depth` configuráveis por grupo
+  - **Traces por grupo**: Com `save_trace=True`, gera `_trace_{nome_grupo}` para grupos
+  - **Validações**: Campos não podem estar em múltiplos grupos; campos em grupos não podem ter `json_schema_extra` de busca
+
 ## [0.5.2] - 2025-01-12
 
 ### Adicionado

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dataframeit"
-version = "0.5.2"
+version = "0.5.3"
 description = "Enriqueça DataFrames com análises de texto usando LLMs. Extraia informações estruturadas de textos com Pydantic."
 readme = "README.md"
 license = "MIT"

--- a/src/dataframeit/llm.py
+++ b/src/dataframeit/llm.py
@@ -1,7 +1,29 @@
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from .utils import check_dependency
 from .errors import retry_with_backoff
+
+
+@dataclass
+class SearchGroupConfig:
+    """Configuração de um grupo de busca.
+
+    Permite agrupar múltiplos campos que compartilham contexto de busca,
+    reduzindo chamadas de API redundantes.
+
+    Attributes:
+        fields: Lista de nomes dos campos que pertencem a este grupo.
+        prompt: Prompt customizado para o grupo. Use {query} para inserir
+            o texto de busca. Se None, usa o prompt padrão.
+        max_results: Número máximo de resultados por busca (1-20).
+            Se None, usa o valor global.
+        search_depth: Profundidade da busca ("basic" ou "advanced").
+            Se None, usa o valor global.
+    """
+    fields: List[str]
+    prompt: Optional[str] = None
+    max_results: Optional[int] = None
+    search_depth: Optional[str] = None
 
 
 @dataclass
@@ -17,6 +39,7 @@ class SearchConfig:
     per_field: bool = False  # Um agente por campo
     max_results: int = 5
     search_depth: str = "basic"  # "basic" ou "advanced" (apenas Tavily)
+    groups: Optional[Dict[str, SearchGroupConfig]] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Add `search_groups` parameter to `dataframeit()` that allows grouping fields that share search context
- Reduces redundant API calls when multiple fields need the same search results
- Add `SearchGroupConfig` dataclass and `call_agent_per_group()` function
- Support custom prompts, max_results, and search_depth per group
- Traces organized by group name (`_trace_{group_name}`)

## Usage Example

```python
result = dataframeit(
    df, MyModel, PROMPT,
    use_search=True,
    search_per_field=True,
    search_groups={
        "regulatory": {
            "fields": ["status_anvisa", "avaliacao_conitec", "existe_pcdt"],
            "prompt": "Search regulatory status: ANVISA, CONITEC, PCDT for {query}",
            "max_results": 5,
            "search_depth": "advanced",
        }
    }
)
```

## Test Plan

- [x] All existing tests pass (144 passed)
- [x] New search_groups tests added (15 tests)
- [x] Validation tests for error cases
- [x] Integration with save_trace verified

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/code)