### PR TITLE
feat: add claude_code provider for Claude Code SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [Unreleased]
+
+### Adicionado
+
+- **`provider='claude_code'` - Suporte ao Claude Code SDK**: Novo provider que usa `claude-agent-sdk` para chamadas LLM via créditos do Claude Code ao invés de créditos de API.
+  - Instale: `pip install dataframeit[claude-code]`
+  - Modelos: `model='haiku'`, `model='sonnet'`, `model='opus'`
+  - Parâmetros via `model_kwargs`: `effort`, `max_turns`, `max_budget_usd`
+  - Não requer API key (usa credenciais do Claude Code)
+  - Busca web (`use_search=True`) não suportada inicialmente
+
 ## [0.5.3] - 2025-01-19
 
 ### Adicionado

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ openai = [
 anthropic = [
     "langchain-anthropic>=0.3.0",
 ]
+claude-code = [
+    "claude-agent-sdk>=0.1.48",
+]
 polars = [
     "polars>=0.20",
 ]
@@ -79,6 +82,7 @@ all = [
     "langchain-anthropic>=0.3.0",
     "langchain-tavily>=0.1.0",
     "langchain-exa>=0.2.0",
+    "claude-agent-sdk>=0.1.48",
     "polars>=0.20",
 ]
 dev = [

--- a/src/dataframeit/claude_code.py
+++ b/src/dataframeit/claude_code.py
@@ -1,0 +1,120 @@
+"""Integração com Claude Code SDK para usar créditos do Claude Code.
+
+Este módulo permite usar o claude-agent-sdk como provider alternativo ao LangChain,
+fazendo chamadas LLM via créditos do Claude Code em vez de créditos de API.
+"""
+import asyncio
+import json
+
+from .llm import LLMConfig, build_prompt
+from .utils import check_dependency, parse_json
+from .errors import retry_with_backoff
+
+
+def _build_json_system_prompt(json_schema: dict) -> str:
+    """Gera system prompt com instruções para output JSON estruturado.
+
+    Args:
+        json_schema: JSON Schema gerado por pydantic_model.model_json_schema().
+
+    Returns:
+        System prompt com schema e instruções de formatação.
+    """
+    schema_str = json.dumps(json_schema, indent=2, ensure_ascii=False)
+    return (
+        "Você é um assistente de extração de dados. "
+        "Responda APENAS com JSON válido seguindo o schema abaixo.\n"
+        "Não inclua texto antes ou depois do JSON. "
+        "Não use blocos de código markdown.\n\n"
+        f"JSON Schema:\n{schema_str}\n\n"
+        "Responda com um único objeto JSON que corresponda exatamente a este schema."
+    )
+
+
+async def _async_query(prompt: str, options):
+    """Executa query assíncrona no claude-agent-sdk.
+
+    Args:
+        prompt: Prompt do usuário.
+        options: ClaudeAgentOptions configurado.
+
+    Returns:
+        Tupla (response_text, cost_usd).
+    """
+    from claude_agent_sdk import query, AssistantMessage, ResultMessage, TextBlock
+
+    response_text = ""
+    cost = None
+
+    async for message in query(prompt=prompt, options=options):
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    response_text += block.text
+        elif isinstance(message, ResultMessage):
+            cost = getattr(message, "total_cost_usd", None)
+
+    return response_text, cost
+
+
+def call_claude_code(text: str, pydantic_model, user_prompt: str, config: LLMConfig) -> dict:
+    """Processa texto usando Claude Code SDK com structured output via JSON schema.
+
+    Args:
+        text: Texto a ser processado.
+        pydantic_model: Modelo Pydantic para estruturar resposta.
+        user_prompt: Template do prompt do usuário.
+        config: Configuração do LLM.
+
+    Returns:
+        Dicionário com 'data' (dados extraídos) e 'usage' (metadata).
+    """
+    check_dependency("claude_agent_sdk", "claude-agent-sdk")
+
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    # Construir prompt e schema
+    prompt = build_prompt(user_prompt, text)
+    json_schema = pydantic_model.model_json_schema()
+    system_prompt = _build_json_system_prompt(json_schema)
+
+    # Construir options a partir de config
+    model_kwargs = config.model_kwargs or {}
+
+    options_kwargs = {
+        "system_prompt": system_prompt,
+        "allowed_tools": [],
+        "permission_mode": "bypassPermissions",
+        "max_turns": model_kwargs.get("max_turns", 1),
+        "max_budget_usd": model_kwargs.get("max_budget_usd", 0.50),
+    }
+
+    if config.model:
+        options_kwargs["model"] = config.model
+
+    effort = model_kwargs.get("effort")
+    if effort:
+        options_kwargs["effort"] = effort
+
+    options = ClaudeAgentOptions(**options_kwargs)
+
+    def _call():
+        response_text, cost = asyncio.run(_async_query(prompt, options))
+
+        if not response_text.strip():
+            raise ValueError("Claude Code SDK retornou resposta vazia")
+
+        # Parse e validação
+        parsed = parse_json(response_text)
+        validated = pydantic_model.model_validate(parsed)
+
+        usage = {
+            'input_tokens': 0,
+            'output_tokens': 0,
+            'total_tokens': 0,
+            'cost_usd': cost,
+        }
+
+        return {'data': validated.model_dump(), 'usage': usage}
+
+    return retry_with_backoff(_call, config.max_retries, config.base_delay, config.max_delay)

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -271,6 +271,13 @@ def dataframeit(
     # Validar dependências ANTES de iniciar (falha rápido com mensagem clara)
     validate_provider_dependencies(provider)
 
+    # Validar busca web com claude_code
+    if use_search and provider == 'claude_code':
+        raise ValueError(
+            "Busca web (use_search=True) não é suportada com provider='claude_code'. "
+            "Use um provider LangChain como 'google_genai' ou 'openai' para busca web."
+        )
+
     # Validar parâmetros de busca
     if use_search:
         if search_provider not in ("tavily", "exa"):
@@ -610,7 +617,8 @@ def _process_rows(
     }
     engine = type_labels.get(conversion_info.original_type, conversion_info.original_type)
     search_mode = '+search' if (config.search_config and config.search_config.enabled) else ''
-    desc = f"Processando [{engine}+langchain{search_mode}]"
+    backend = 'claude_code' if config.provider == 'claude_code' else 'langchain'
+    desc = f"Processando [{engine}+{backend}{search_mode}]"
 
     # Adicionar info de rate limiting (se ativo)
     if config.rate_limit_delay > 0:
@@ -658,6 +666,9 @@ def _process_rows(
                         result = call_agent_per_field(text, pydantic_model, user_prompt, config, trace_mode)
                 else:
                     result = call_agent(text, pydantic_model, user_prompt, config, trace_mode)
+            elif config.provider == 'claude_code':
+                from .claude_code import call_claude_code
+                result = call_claude_code(text, pydantic_model, user_prompt, config)
             else:
                 result = call_langchain(text, pydantic_model, user_prompt, config)
 
@@ -796,7 +807,8 @@ def _process_rows_parallel(
     }
     engine = type_labels.get(conversion_info.original_type, conversion_info.original_type)
     search_mode = '+search' if (config.search_config and config.search_config.enabled) else ''
-    desc = f"Processando [{engine}+langchain{search_mode}] [{parallel_requests} workers]"
+    backend = 'claude_code' if config.provider == 'claude_code' else 'langchain'
+    desc = f"Processando [{engine}+{backend}{search_mode}] [{parallel_requests} workers]"
 
     if reprocess_columns:
         desc += f" (reprocessando: {', '.join(reprocess_columns)})"
@@ -840,6 +852,9 @@ def _process_rows_parallel(
                         result = call_agent_per_field(text, pydantic_model, user_prompt, config, trace_mode)
                 else:
                     result = call_agent(text, pydantic_model, user_prompt, config, trace_mode)
+            elif config.provider == 'claude_code':
+                from .claude_code import call_claude_code
+                result = call_claude_code(text, pydantic_model, user_prompt, config)
             else:
                 result = call_langchain(text, pydantic_model, user_prompt, config)
 

--- a/src/dataframeit/errors.py
+++ b/src/dataframeit/errors.py
@@ -89,6 +89,7 @@ def _infer_provider_info(provider: str) -> dict:
         'fireworks': 'Fireworks AI',
         'together': 'Together AI',
         'groq': 'Groq',
+        'claude_code': 'Claude Code',
     }
     name = name_map.get(provider, provider.replace('_', ' ').title())
 
@@ -129,11 +130,21 @@ def validate_provider_dependencies(provider: str):
     """Valida se as dependências do provider estão instaladas ANTES de iniciar.
 
     Args:
-        provider: Nome do provider (google_genai, openai, anthropic, etc).
+        provider: Nome do provider (google_genai, openai, anthropic, claude_code, etc).
 
     Raises:
         ImportError: Com mensagem amigável se dependência não estiver instalada.
     """
+    # Claude Code SDK não precisa de LangChain
+    if provider == 'claude_code':
+        try:
+            importlib.import_module('claude_agent_sdk')
+        except ImportError:
+            raise ImportError(_get_missing_package_message(
+                'claude_agent_sdk', 'claude-agent-sdk', 'Claude Code SDK'
+            ))
+        return
+
     # Validar LangChain base
     try:
         importlib.import_module('langchain')

--- a/src/dataframeit/errors.py
+++ b/src/dataframeit/errors.py
@@ -139,10 +139,10 @@ def validate_provider_dependencies(provider: str):
     if provider == 'claude_code':
         try:
             importlib.import_module('claude_agent_sdk')
-        except ImportError:
+        except ImportError as err:
             raise ImportError(_get_missing_package_message(
                 'claude_agent_sdk', 'claude-agent-sdk', 'Claude Code SDK'
-            ))
+            )) from err
         return
 
     # Validar LangChain base

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -56,7 +56,7 @@ class TestUseSearchWithClaudeCode:
         from dataframeit import dataframeit
 
         with patch('dataframeit.core.validate_provider_dependencies'):
-            with pytest.raises(ValueError, match="use_search.*claude_code"):
+            with pytest.raises(ValueError, match=r"use_search.*claude_code"):
                 dataframeit(
                     ["texto teste"],
                     questions=SampleModel,

--- a/tests/test_claude_code.py
+++ b/tests/test_claude_code.py
@@ -1,0 +1,119 @@
+"""Testes para o provider claude_code (Claude Code SDK)."""
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from pydantic import BaseModel
+
+
+class SampleModel(BaseModel):
+    sentimento: str
+    confianca: float
+
+
+class TestValidateProviderDependencies:
+    """Testes para validação de dependências do provider claude_code."""
+
+    def test_claude_code_missing_raises_import_error(self):
+        """Deve levantar ImportError com mensagem amigável quando claude_agent_sdk não está instalado."""
+        from dataframeit.errors import validate_provider_dependencies
+
+        with patch('importlib.import_module', side_effect=ImportError("No module")):
+            with pytest.raises(ImportError, match="claude_agent_sdk"):
+                validate_provider_dependencies('claude_code')
+
+    def test_claude_code_installed_passes(self):
+        """Deve passar sem erro quando claude_agent_sdk está instalado."""
+        from dataframeit.errors import validate_provider_dependencies
+
+        with patch('importlib.import_module', return_value=MagicMock()):
+            # Não deve levantar exceção
+            validate_provider_dependencies('claude_code')
+
+    def test_claude_code_skips_langchain_validation(self):
+        """Deve NÃO validar langchain quando provider é claude_code."""
+        from dataframeit.errors import validate_provider_dependencies
+
+        call_args = []
+
+        def mock_import(name):
+            call_args.append(name)
+            return MagicMock()
+
+        with patch('importlib.import_module', side_effect=mock_import):
+            validate_provider_dependencies('claude_code')
+
+        # Deve ter importado apenas claude_agent_sdk, não langchain
+        assert 'claude_agent_sdk' in call_args
+        assert 'langchain' not in call_args
+        assert 'langchain_core' not in call_args
+
+
+class TestUseSearchWithClaudeCode:
+    """Testes para validação de use_search com claude_code."""
+
+    def test_use_search_with_claude_code_raises(self):
+        """Deve levantar ValueError quando use_search=True com provider='claude_code'."""
+        from dataframeit import dataframeit
+
+        with patch('dataframeit.core.validate_provider_dependencies'):
+            with pytest.raises(ValueError, match="use_search.*claude_code"):
+                dataframeit(
+                    ["texto teste"],
+                    questions=SampleModel,
+                    prompt="Analise: {texto}",
+                    provider='claude_code',
+                    model='haiku',
+                    use_search=True,
+                )
+
+
+class TestBuildJsonSystemPrompt:
+    """Testes para geração do system prompt com JSON schema."""
+
+    def test_includes_json_schema(self):
+        """System prompt deve incluir o JSON schema do modelo Pydantic."""
+        from dataframeit.claude_code import _build_json_system_prompt
+
+        schema = SampleModel.model_json_schema()
+        prompt = _build_json_system_prompt(schema)
+
+        assert 'sentimento' in prompt
+        assert 'confianca' in prompt
+        assert 'JSON Schema' in prompt
+
+    def test_instructs_json_only(self):
+        """System prompt deve instruir resposta apenas em JSON."""
+        from dataframeit.claude_code import _build_json_system_prompt
+
+        schema = SampleModel.model_json_schema()
+        prompt = _build_json_system_prompt(schema)
+
+        assert 'APENAS' in prompt or 'JSON' in prompt
+
+
+class TestJsonParsingVariants:
+    """Testes para parsing de diferentes formatos de resposta."""
+
+    def test_plain_json(self):
+        """Deve parsear JSON puro."""
+        from dataframeit.utils import parse_json
+
+        result = parse_json('{"sentimento": "positivo", "confianca": 0.95}')
+        assert result['sentimento'] == 'positivo'
+        assert result['confianca'] == 0.95
+
+    def test_json_with_markdown_fences(self):
+        """Deve parsear JSON dentro de blocos markdown."""
+        from dataframeit.utils import parse_json
+
+        response = '```json\n{"sentimento": "negativo", "confianca": 0.8}\n```'
+        result = parse_json(response)
+        assert result['sentimento'] == 'negativo'
+
+    def test_json_with_surrounding_text(self):
+        """Deve extrair JSON de resposta com texto ao redor."""
+        from dataframeit.utils import parse_json
+
+        response = 'Aqui está o resultado: {"sentimento": "neutro", "confianca": 0.5} fim.'
+        result = parse_json(response)
+        assert result['sentimento'] == 'neutro'


### PR DESCRIPTION
## Summary

- Adiciona `provider='claude_code'` como novo provider que usa `claude-agent-sdk` para fazer chamadas LLM via créditos do Claude Code ao invés de créditos de API
- Novo módulo `src/dataframeit/claude_code.py` com `call_claude_code()` que faz a ponte async→sync e converte schema Pydantic em instruções de JSON no system prompt
- Dependência opcional: `pip install dataframeit[claude-code]`

## Uso

```python
result = dataframeit(
    ["O produto é excelente!", "Péssimo atendimento."],
    questions=Sentimento,
    prompt="Analise o sentimento do texto: {texto}",
    model="haiku",  # ou "sonnet", "opus"
    provider="claude_code",
    model_kwargs={"effort": "medium", "max_budget_usd": 0.50},
)
```

## Test plan

- [x] 9 novos testes unitários em `tests/test_claude_code.py`
- [x] Suite completa: 252 testes passando (247 passed, 5 skipped)
- [ ] Teste manual com créditos Claude Code (requer `claude-agent-sdk` instalado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code provider that uses Claude Code credits for LLM operations instead of API credits.
  * Supports Haiku, Sonnet, and Opus models with configurable effort, max turns, and budget limits.
  * Requires Claude Code credentials; no API key needed.
  * Note: Web search functionality is not yet supported with this provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->