### PR TITLE
feat(providers): add Groq as optional provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ### Adicionado
 
-- **Suporte opcional a Groq**: novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
+- **Suporte opcional a Groq** (#94): novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
 
 ## [0.5.4] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+### Adicionado
+
+- **Suporte opcional a Groq**: novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
+
 ## [0.5.4] - 2026-04-13
 
 ### Adicionado

--- a/docs/en/guides/providers.md
+++ b/docs/en/guides/providers.md
@@ -9,7 +9,7 @@ Configure different LLM providers via LangChain.
 | Google | `google_genai` | gemini-3-flash-preview, gemini-2.5-flash, gemini-2.5-pro |
 | OpenAI | `openai` | gpt-5.2, gpt-5.2-mini, gpt-4.1 |
 | Anthropic | `anthropic` | claude-sonnet-4-5, claude-opus-4-6, claude-haiku-4-5 |
-| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b |
+| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b, groq/compound |
 | Cohere | `cohere` | command-r, command-r-plus |
 | Mistral | `mistral` | mistral-large, mistral-small |
 

--- a/docs/en/guides/providers.md
+++ b/docs/en/guides/providers.md
@@ -9,6 +9,7 @@ Configure different LLM providers via LangChain.
 | Google | `google_genai` | gemini-3-flash-preview, gemini-2.5-flash, gemini-2.5-pro |
 | OpenAI | `openai` | gpt-5.2, gpt-5.2-mini, gpt-4.1 |
 | Anthropic | `anthropic` | claude-sonnet-4-5, claude-opus-4-6, claude-haiku-4-5 |
+| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b |
 | Cohere | `cohere` | command-r, command-r-plus |
 | Mistral | `mistral` | mistral-large, mistral-small |
 
@@ -121,6 +122,63 @@ result = dataframeit(
 | `claude-sonnet-4-5` | General use, excellent quality | Medium |
 | `claude-opus-4-6` | Maximum quality, agentic | High |
 | `claude-haiku-4-5` | Fast, economical | Low |
+
+## Groq
+
+```bash
+pip install dataframeit[groq]
+export GROQ_API_KEY="your-key"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='groq',
+    model='llama-3.3-70b-versatile'
+)
+
+# Faster / cheaper model
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='groq',
+    model='llama-3.1-8b-instant',
+    model_kwargs={
+        'temperature': 0.2
+    }
+)
+
+# GPT-OSS for heavier reasoning tasks
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='groq',
+    model='openai/gpt-oss-120b'
+)
+```
+
+### Recommended Models
+
+Production:
+
+| Model | Context | Throughput | Use |
+|-------|---------|-----------|-----|
+| `llama-3.3-70b-versatile` | 131K | ~280 t/s | General use, good quality |
+| `llama-3.1-8b-instant` | 131K | ~560 t/s | High speed, economical |
+| `openai/gpt-oss-120b` | 131K | ~500 t/s | Reasoning, complex tasks |
+| `openai/gpt-oss-20b` | 131K | ~1000 t/s | Faster than 120b, low cost |
+| `groq/compound` | - | ~450 t/s | Agentic system with built-in web search and code execution |
+
+Preview (may change or be deprecated):
+
+| Model | Use |
+|-------|-----|
+| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout, high speed |
+| `qwen/qwen3-32b` | Qwen3, good for reasoning |
+
+!!! note "Availability and free tier"
+    Groq offers a free tier with per-minute request limits per model. The model catalog changes frequently (especially `preview` models); check [console.groq.com/docs/models](https://console.groq.com/docs/models) for the current list and limits.
 
 ## Cohere
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -9,7 +9,7 @@ Configure diferentes provedores de LLM via LangChain.
 | Google | `google_genai` | gemini-3-flash-preview, gemini-2.5-flash, gemini-2.5-pro |
 | OpenAI | `openai` | gpt-5.2, gpt-5.2-mini, gpt-4.1 |
 | Anthropic | `anthropic` | claude-sonnet-4-5, claude-opus-4-6, claude-haiku-4-5 |
-| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b |
+| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b, groq/compound |
 | Cohere | `cohere` | command-r, command-r-plus |
 | Mistral | `mistral` | mistral-large, mistral-small |
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -9,6 +9,7 @@ Configure diferentes provedores de LLM via LangChain.
 | Google | `google_genai` | gemini-3-flash-preview, gemini-2.5-flash, gemini-2.5-pro |
 | OpenAI | `openai` | gpt-5.2, gpt-5.2-mini, gpt-4.1 |
 | Anthropic | `anthropic` | claude-sonnet-4-5, claude-opus-4-6, claude-haiku-4-5 |
+| Groq | `groq` | llama-3.3-70b-versatile, llama-3.1-8b-instant, openai/gpt-oss-120b, openai/gpt-oss-20b |
 | Cohere | `cohere` | command-r, command-r-plus |
 | Mistral | `mistral` | mistral-large, mistral-small |
 
@@ -115,6 +116,60 @@ resultado = dataframeit(
 | `claude-sonnet-4-5` | Uso geral, excelente qualidade | Médio |
 | `claude-opus-4-6` | Máxima qualidade, agentic | Alto |
 | `claude-haiku-4-5` | Rápido, econômico | Baixo |
+
+## Groq
+
+```bash
+pip install dataframeit[groq]
+export GROQ_API_KEY="sua-chave"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='groq',
+    model='llama-3.3-70b-versatile'
+)
+
+# Modelo mais rápido/econômico
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='groq',
+    model='llama-3.1-8b-instant',
+    model_kwargs={
+        'temperature': 0.2
+    }
+)
+
+# GPT-OSS para tarefas com raciocínio mais pesado
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='groq',
+    model='openai/gpt-oss-120b'
+)
+```
+
+### Modelos Recomendados
+
+Produção:
+
+| Modelo | Contexto | Throughput | Uso |
+|--------|----------|-----------|-----|
+| `llama-3.3-70b-versatile` | 131K | ~280 t/s | Uso geral, boa qualidade |
+| `llama-3.1-8b-instant` | 131K | ~560 t/s | Alta velocidade, econômico |
+| `openai/gpt-oss-120b` | 131K | ~500 t/s | Raciocínio, tarefas complexas |
+| `openai/gpt-oss-20b` | 131K | ~1000 t/s | Mais rápido que o 120b, custo baixo |
+| `groq/compound` | - | ~450 t/s | Sistema agêntico com web search e execução de código embutidos |
+
+Preview (podem mudar ou ser descontinuados):
+
+| Modelo | Uso |
+|--------|-----|
+| `meta-llama/llama-4-scout-17b-16e-instruct` | Llama 4 Scout, alta velocidade |
+| `qwen/qwen3-32b` | Qwen3, bom para reasoning |
+
+!!! note "Disponibilidade e free tier"
+    O Groq oferece free tier com limites de requisições por minuto por modelo. A lista de modelos muda com frequência (especialmente os `preview`); verifique [console.groq.com/docs/models](https://console.groq.com/docs/models) para o catálogo atual e limites.
 
 ## Cohere
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ openai = [
 anthropic = [
     "langchain-anthropic>=0.3.0",
 ]
+groq = [
+    "langchain-groq>=0.2.0",
+]
 claude-code = [
     "claude-agent-sdk>=0.1.48",
 ]
@@ -80,6 +83,7 @@ all = [
     "langchain-google-genai>=2.0.0",
     "langchain-openai>=0.3.0",
     "langchain-anthropic>=0.3.0",
+    "langchain-groq>=0.2.0",
     "langchain-tavily>=0.1.0",
     "langchain-exa>=0.2.0",
     "claude-agent-sdk>=0.1.48",


### PR DESCRIPTION
## Summary
- Adiciona `groq` como extra opcional em `pyproject.toml` (`pip install dataframeit[groq]`) e inclui `langchain-groq>=0.2.0` no extra `all`.
- Documenta o provider em `docs/guides/providers.md` e `docs/en/guides/providers.md` com os modelos atualmente disponíveis no Groq (produção: `llama-3.3-70b-versatile`, `llama-3.1-8b-instant`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b`, `groq/compound`; preview: `meta-llama/llama-4-scout-17b-16e-instruct`, `qwen/qwen3-32b`).
- Registra a adição no `CHANGELOG.md` sob `[Unreleased]`.

Não altera o default (`provider='google_genai'` / `model='gemini-3-flash-preview'`); `langchain-groq` continua fora das dependências obrigatórias.

Substitui #86 (fechado), que tentava tornar Groq o default e embarcava `langchain-groq` como dependência obrigatória.

## Test plan
- [x] `uv sync --extra groq` instala `langchain-groq` e `groq`.
- [x] `uv run pytest` passa (247 passed, 5 skipped).
- [x] `from langchain_groq import ChatGroq` + `validate_provider_dependencies("groq")` funcionam.
- [ ] Smoke test manual com `provider='groq'` e `GROQ_API_KEY` válida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Groq as a supported LLM provider. Install with `pip install dataframeit[groq]`, configure the `GROQ_API_KEY` environment variable, and specify `provider='groq'` in calls. Documentation includes setup instructions, usage examples, and recommended model listings for both production and preview tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->