### PR TITLE
fix(search): warn when config may exceed rate limit (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 ### Adicionado
 
 - **Suporte opcional a Groq** (#94): novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
+- **Aviso de rate limit para busca web** (#67): `dataframeit(...)` agora emite um `UserWarning` quando a combinação de `use_search=True`, `parallel_requests` e `search_per_field` pode exceder o rate limit do provedor de busca (Tavily ou Exa). A mensagem inclui recomendações específicas de `parallel_requests` e `rate_limit_delay`. O aviso também dispara em execuções sequenciais quando o total de queries estimadas (`linhas × campos`) ultrapassa 100.
+- Documentação de rate limits e processamento paralelo em `docs/guides/web-search.md` e `docs/en/guides/web-search.md`, com tabelas de configurações recomendadas por provedor.
 
 ## [0.5.4] - 2026-04-13
 

--- a/docs/en/guides/web-search.md
+++ b/docs/en/guides/web-search.md
@@ -352,3 +352,65 @@ result = dataframeit(
 2. Prefer `search_depth='basic'`
 3. Filter your DataFrame before processing
 4. Use `search_per_field=False` when possible
+
+## Rate Limits and Parallel Processing
+
+!!! danger "HTTP 429 errors"
+    Using `parallel_requests` with web search can easily exceed the search provider's rate limits. Searches then fail silently and return incomplete data.
+
+### Provider Limits
+
+| Provider | Approximate rate limit |
+|----------|-----------------------|
+| Tavily   | ~100 req/min          |
+| Exa      | ~300 req/min          |
+
+If you need higher throughput, consider `search_provider="exa"`.
+
+### How Queries are Counted
+
+| Configuration | Queries per row |
+|---------------|-----------------|
+| `search_per_field=False` | 1 per row |
+| `search_per_field=True` | 1 per field, per row |
+
+With `parallel_requests=20` and `search_per_field=True` on a 4-field model, you can fire ~80 concurrent queries — well above either provider's limit.
+
+### Recommended Settings
+
+**Tavily (default):**
+
+| Scenario | `parallel_requests` | `rate_limit_delay` |
+|----------|---------------------|--------------------|
+| `search_per_field=False` | 5–10 | 0.5s |
+| `search_per_field=True` (2–3 fields) | 3–5 | 0.5s |
+| `search_per_field=True` (4+ fields) | 2–3 | 1.0s |
+
+**Exa:**
+
+| Scenario | `parallel_requests` | `rate_limit_delay` |
+|----------|---------------------|--------------------|
+| `search_per_field=False` | 10–15 | 0.3s |
+| `search_per_field=True` (2–3 fields) | 5–8 | 0.3s |
+| `search_per_field=True` (4+ fields) | 3–5 | 0.5s |
+
+```python
+# Safe settings for Tavily with multiple fields
+result = dataframeit(
+    df, Model, PROMPT,
+    use_search=True, search_per_field=True,
+    parallel_requests=3, rate_limit_delay=0.5,
+)
+
+# Higher throughput with Exa
+result = dataframeit(
+    df, Model, PROMPT,
+    use_search=True, search_provider="exa",
+    search_per_field=True,
+    parallel_requests=5, rate_limit_delay=0.3,
+)
+```
+
+### Automatic Warning
+
+DataFrameIt emits a `UserWarning` when the configuration looks risky (high concurrent queries or estimated rate close to the provider limit), with recommended `parallel_requests` and `rate_limit_delay` values to avoid HTTP 429. The warning also fires on sequential runs when `search_per_field=True` produces many queries (>100 total).

--- a/docs/guides/web-search.md
+++ b/docs/guides/web-search.md
@@ -432,3 +432,65 @@ resultado = dataframeit(
 2. Prefira `search_depth='basic'`
 3. Filtre seu DataFrame antes de processar
 4. Use `search_per_field=False` quando possível
+
+## Rate Limits e Processamento Paralelo
+
+!!! danger "Erros HTTP 429"
+    Ao usar `parallel_requests` com busca web, é fácil exceder os limites de taxa do provedor de busca. Isso faz com que buscas falhem silenciosamente e retornem dados incompletos.
+
+### Limites por Provedor
+
+| Provedor | Rate limit aproximado |
+|----------|----------------------|
+| Tavily   | ~100 req/min         |
+| Exa      | ~300 req/min         |
+
+Se você precisa de maior throughput, considere `search_provider="exa"`.
+
+### Como as Queries são Contadas
+
+| Configuração | Queries por linha |
+|--------------|------------------|
+| `search_per_field=False` | 1 por linha |
+| `search_per_field=True` | 1 por campo, por linha |
+
+Com `parallel_requests=20` e `search_per_field=True` em um modelo de 4 campos, podem ir ~80 queries concorrentes — muito acima dos limites dos provedores.
+
+### Configurações Recomendadas
+
+**Tavily (padrão):**
+
+| Cenário | `parallel_requests` | `rate_limit_delay` |
+|---------|---------------------|--------------------|
+| `search_per_field=False` | 5–10 | 0.5s |
+| `search_per_field=True` (2–3 campos) | 3–5 | 0.5s |
+| `search_per_field=True` (4+ campos) | 2–3 | 1.0s |
+
+**Exa:**
+
+| Cenário | `parallel_requests` | `rate_limit_delay` |
+|---------|---------------------|--------------------|
+| `search_per_field=False` | 10–15 | 0.3s |
+| `search_per_field=True` (2–3 campos) | 5–8 | 0.3s |
+| `search_per_field=True` (4+ campos) | 3–5 | 0.5s |
+
+```python
+# Configuração segura com Tavily e múltiplos campos
+resultado = dataframeit(
+    df, Model, PROMPT,
+    use_search=True, search_per_field=True,
+    parallel_requests=3, rate_limit_delay=0.5,
+)
+
+# Maior throughput com Exa
+resultado = dataframeit(
+    df, Model, PROMPT,
+    use_search=True, search_provider="exa",
+    search_per_field=True,
+    parallel_requests=5, rate_limit_delay=0.3,
+)
+```
+
+### Aviso Automático
+
+O DataFrameIt emite um `UserWarning` quando a configuração parece arriscada (queries concorrentes altas ou taxa estimada perto do limite), incluindo recomendações de `parallel_requests` e `rate_limit_delay` para evitar HTTP 429. O gatilho também dispara em execuções sequenciais quando `search_per_field=True` produz muitas queries (>100 no total).

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -31,6 +31,88 @@ logging.getLogger('httpx').setLevel(logging.WARNING)
 _FIELD_CONFIG_KEYS = ('prompt', 'prompt_replace', 'prompt_append', 'search_depth', 'max_results')
 
 
+# Limites aproximados de requisições por minuto por provedor de busca.
+_SEARCH_PROVIDER_RATE_LIMITS = {
+    'tavily': 100,  # plano gratuito/básico: ~100 req/min
+    'exa': 300,     # plano padrão: ~5 QPS = ~300 req/min
+}
+
+# Limite de queries concorrentes acima do qual vale avisar o usuário.
+_RECOMMENDED_MAX_CONCURRENT_SEARCH_QUERIES = 10
+
+
+def _warn_search_rate_limit(
+    num_rows: int,
+    num_fields: int,
+    parallel_requests: int,
+    search_per_field: bool,
+    rate_limit_delay: float,
+    search_provider: str = "tavily",
+) -> None:
+    """Avisa quando a configuração pode exceder rate limits do provedor de busca.
+
+    Dispara quando (a) o número de queries concorrentes é alto ou (b) a taxa
+    estimada ultrapassa ~80% do limite do provedor. Inclui recomendações de
+    ``parallel_requests`` e ``rate_limit_delay`` seguros.
+    """
+    queries_per_row = num_fields if search_per_field else 1
+    total_queries = num_rows * queries_per_row
+    concurrent_queries = parallel_requests * queries_per_row
+
+    provider_limit = _SEARCH_PROVIDER_RATE_LIMITS.get(
+        search_provider, _SEARCH_PROVIDER_RATE_LIMITS['tavily']
+    )
+    provider_name = search_provider.capitalize()
+
+    issues: list[str] = []
+
+    if concurrent_queries > _RECOMMENDED_MAX_CONCURRENT_SEARCH_QUERIES:
+        issues.append(
+            f"queries concorrentes estimadas: {concurrent_queries} "
+            f"(limite recomendado: {_RECOMMENDED_MAX_CONCURRENT_SEARCH_QUERIES})"
+        )
+
+    if rate_limit_delay > 0:
+        estimated_rpm = (60 / rate_limit_delay) * parallel_requests
+    else:
+        estimated_rpm = parallel_requests * 60
+    if search_per_field:
+        estimated_rpm *= num_fields
+
+    if estimated_rpm > provider_limit * 0.8:
+        issues.append(
+            f"taxa estimada ~{estimated_rpm:.0f} req/min "
+            f"(limite {provider_name}: ~{provider_limit}/min)"
+        )
+
+    if not issues:
+        return
+
+    # Recomendações: reduzir paralelismo e sugerir delay adequado ao provedor.
+    if search_per_field:
+        recommended_parallel = max(1, _RECOMMENDED_MAX_CONCURRENT_SEARCH_QUERIES // num_fields)
+        recommended_delay = (60 * recommended_parallel * num_fields) / (provider_limit * 0.7)
+    else:
+        recommended_parallel = min(parallel_requests, _RECOMMENDED_MAX_CONCURRENT_SEARCH_QUERIES)
+        recommended_delay = (60 * recommended_parallel) / (provider_limit * 0.7)
+    recommended_parallel = max(1, recommended_parallel)
+    recommended_delay = max(0.5, round(recommended_delay, 1))
+
+    recs = [f"parallel_requests={recommended_parallel}"]
+    if rate_limit_delay < recommended_delay:
+        recs.append(f"rate_limit_delay={recommended_delay}")
+
+    msg = (
+        f"Configuração pode exceder rate limits de busca ({provider_name}). "
+        f"parallel_requests={parallel_requests}, search_per_field={search_per_field}, "
+        f"rate_limit_delay={rate_limit_delay}s, total de queries estimadas={total_queries}. "
+        + "Problemas: " + "; ".join(issues) + ". "
+        + "Para evitar HTTP 429, use: " + ", ".join(recs) + "."
+    )
+
+    warnings.warn(msg, UserWarning, stacklevel=3)
+
+
 def _validate_search_groups(
     search_groups: Dict[str, dict],
     pydantic_model,
@@ -334,6 +416,23 @@ def dataframeit(
     expected_columns = list(questions.model_fields.keys())
     if not expected_columns:
         raise ValueError("Modelo Pydantic não pode estar vazio")
+
+    # Avisar sobre rate limits de busca quando a configuração parece arriscada.
+    # Cobre tanto paralelismo alto quanto search_per_field em datasets grandes
+    # mesmo sem paralelismo — ambos podem estourar o limite do provedor.
+    if use_search:
+        is_risky = parallel_requests > 1 or (
+            search_per_field and len(expected_columns) * len(df_pandas) > 100
+        )
+        if is_risky:
+            _warn_search_rate_limit(
+                num_rows=len(df_pandas),
+                num_fields=len(expected_columns),
+                parallel_requests=parallel_requests,
+                search_per_field=search_per_field,
+                rate_limit_delay=rate_limit_delay,
+                search_provider=search_provider,
+            )
 
     # Validar e processar search_groups
     if search_groups:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1994,5 +1994,226 @@ def test_issue_84_search_count_per_item():
         f"search_count deveria ser 3, mas é {result['usage']['search_count']}"
 
 
+# =============================================================================
+# Testes de warning de rate limit (Issue #67)
+# =============================================================================
+
+def test_warn_search_rate_limit_triggers_on_high_concurrent():
+    """Emite warning quando queries concorrentes excedem limite recomendado."""
+    from dataframeit.core import _warn_search_rate_limit
+
+    with pytest.warns(UserWarning) as record:
+        _warn_search_rate_limit(
+            num_rows=100,
+            num_fields=4,
+            parallel_requests=20,
+            search_per_field=True,
+            rate_limit_delay=0.0,
+        )
+
+    assert len(record) == 1
+    msg = str(record[0].message)
+    assert "rate limit" in msg.lower()
+    assert "80" in msg  # 20 * 4 = 80 queries concorrentes
+    assert "parallel_requests=" in msg
+    assert "rate_limit_delay=" in msg
+
+
+def test_warn_search_rate_limit_triggers_on_high_rpm():
+    """Emite warning quando taxa estimada excede o limite do Tavily."""
+    from dataframeit.core import _warn_search_rate_limit
+
+    with pytest.warns(UserWarning) as record:
+        _warn_search_rate_limit(
+            num_rows=1000,
+            num_fields=1,
+            parallel_requests=10,
+            search_per_field=False,
+            rate_limit_delay=0.0,
+        )
+
+    assert len(record) == 1
+    assert "req/min" in str(record[0].message).lower()
+
+
+def test_warn_search_rate_limit_silent_on_safe_config():
+    """Não emite warning com configuração conservadora."""
+    import warnings as _warnings
+    from dataframeit.core import _warn_search_rate_limit
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _warn_search_rate_limit(
+            num_rows=10,
+            num_fields=1,
+            parallel_requests=2,
+            search_per_field=False,
+            rate_limit_delay=2.0,
+        )
+
+    assert not any("rate limit" in str(x.message).lower() for x in w)
+
+
+def test_warn_search_rate_limit_exa_higher_threshold():
+    """Exa tem limite 3x maior — configuração que alerta Tavily pode não alertar Exa."""
+    import warnings as _warnings
+    from dataframeit.core import _warn_search_rate_limit
+
+    # Configuração: 10 queries concorrentes está no limite (10), não dispara.
+    # A diferença que exercitamos é a taxa estimada:
+    # rate_limit_delay=2.0, parallel=5 => 5 * 30 = 150 rpm
+    # Tavily 80% = 80 -> dispara. Exa 80% = 240 -> não dispara.
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _warn_search_rate_limit(
+            num_rows=50,
+            num_fields=1,
+            parallel_requests=5,
+            search_per_field=False,
+            rate_limit_delay=2.0,
+            search_provider="tavily",
+        )
+    assert any("rate limit" in str(x.message).lower() for x in w)
+
+    with _warnings.catch_warnings(record=True) as w:
+        _warnings.simplefilter("always")
+        _warn_search_rate_limit(
+            num_rows=50,
+            num_fields=1,
+            parallel_requests=5,
+            search_per_field=False,
+            rate_limit_delay=2.0,
+            search_provider="exa",
+        )
+    assert not any("rate limit" in str(x.message).lower() for x in w)
+
+
+def test_warn_search_rate_limit_shows_provider_name():
+    """A mensagem cita o provedor atual."""
+    from dataframeit.core import _warn_search_rate_limit
+
+    with pytest.warns(UserWarning) as record:
+        _warn_search_rate_limit(
+            num_rows=100, num_fields=4, parallel_requests=20,
+            search_per_field=True, rate_limit_delay=0.0, search_provider="tavily",
+        )
+    assert "Tavily" in str(record[0].message)
+
+    with pytest.warns(UserWarning) as record:
+        _warn_search_rate_limit(
+            num_rows=100, num_fields=4, parallel_requests=20,
+            search_per_field=True, rate_limit_delay=0.0, search_provider="exa",
+        )
+    assert "Exa" in str(record[0].message)
+
+
+def test_dataframeit_warns_when_search_and_parallel():
+    """dataframeit chama _warn_search_rate_limit com use_search + parallel>1."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"texto": ["item"] * 100})
+
+    with patch('dataframeit.core.validate_provider_dependencies'), \
+         patch('dataframeit.core.validate_search_dependencies'), \
+         patch('dataframeit.core._warn_search_rate_limit') as mock_warn, \
+         patch('dataframeit.core._process_rows_parallel') as mock_process:
+        mock_process.return_value = {'total_tokens': 0}
+        try:
+            dataframeit(
+                df, questions=MedicamentoInfo, prompt="Pesquise {texto}",
+                use_search=True, search_per_field=True, parallel_requests=10,
+            )
+        except Exception:
+            pass
+        mock_warn.assert_called_once()
+        kwargs = mock_warn.call_args.kwargs
+        assert kwargs['num_rows'] == 100
+        assert kwargs['num_fields'] == 2  # MedicamentoInfo tem 2 campos
+        assert kwargs['parallel_requests'] == 10
+        assert kwargs['search_per_field'] is True
+
+
+def test_dataframeit_warns_per_field_large_dataset_without_parallel():
+    """Mesmo sem paralelismo, search_per_field com muitas queries aciona o warning."""
+    from dataframeit.core import dataframeit
+
+    # 100 linhas * 2 campos = 200 queries -> > 100, aciona gatilho estendido.
+    df = pd.DataFrame({"texto": ["item"] * 100})
+
+    with patch('dataframeit.core.validate_provider_dependencies'), \
+         patch('dataframeit.core.validate_search_dependencies'), \
+         patch('dataframeit.core._warn_search_rate_limit') as mock_warn, \
+         patch('dataframeit.core._process_rows') as mock_process:
+        mock_process.return_value = {'total_tokens': 0}
+        try:
+            dataframeit(
+                df, questions=MedicamentoInfo, prompt="Pesquise {texto}",
+                use_search=True, search_per_field=True, parallel_requests=1,
+            )
+        except Exception:
+            pass
+        mock_warn.assert_called_once()
+
+
+def test_dataframeit_no_warn_without_search():
+    """Sem use_search, não chama _warn_search_rate_limit."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"texto": ["item"]})
+    with patch('dataframeit.core.validate_provider_dependencies'), \
+         patch('dataframeit.core._warn_search_rate_limit') as mock_warn, \
+         patch('dataframeit.core._process_rows_parallel') as mock_process:
+        mock_process.return_value = {'total_tokens': 0}
+        try:
+            dataframeit(
+                df, questions=MedicamentoInfo, prompt="Analise {texto}",
+                use_search=False, parallel_requests=10,
+            )
+        except Exception:
+            pass
+        mock_warn.assert_not_called()
+
+
+def test_dataframeit_no_warn_small_sequential_search():
+    """Busca sequencial em dataset pequeno não dispara o warning."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"texto": ["item"]})  # 1 linha * 2 campos = 2 queries
+    with patch('dataframeit.core.validate_provider_dependencies'), \
+         patch('dataframeit.core.validate_search_dependencies'), \
+         patch('dataframeit.core._warn_search_rate_limit') as mock_warn, \
+         patch('dataframeit.core._process_rows') as mock_process:
+        mock_process.return_value = {'total_tokens': 0}
+        try:
+            dataframeit(
+                df, questions=MedicamentoInfo, prompt="Pesquise {texto}",
+                use_search=True, search_per_field=False, parallel_requests=1,
+            )
+        except Exception:
+            pass
+        mock_warn.assert_not_called()
+
+
+def test_dataframeit_passes_search_provider_to_warning():
+    """O search_provider configurado chega no warning."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"texto": ["item"] * 100})
+    with patch('dataframeit.core.validate_provider_dependencies'), \
+         patch('dataframeit.core.validate_search_dependencies'), \
+         patch('dataframeit.core._warn_search_rate_limit') as mock_warn, \
+         patch('dataframeit.core._process_rows_parallel') as mock_process:
+        mock_process.return_value = {'total_tokens': 0}
+        try:
+            dataframeit(
+                df, questions=MedicamentoInfo, prompt="Pesquise {texto}",
+                use_search=True, search_provider="exa", parallel_requests=10,
+            )
+        except Exception:
+            pass
+        mock_warn.assert_called_once()
+        assert mock_warn.call_args.kwargs['search_provider'] == "exa"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #67.

## Summary
- Adiciona `_warn_search_rate_limit()` em `src/dataframeit/core.py` que emite um `UserWarning` quando `use_search=True` combinado com `parallel_requests` e/ou `search_per_field` pode exceder o rate limit do provedor de busca.
- Suporte aos dois provedores em uso: Tavily (~100 req/min) e Exa (~300 req/min).
- Trigger também dispara em execuções sequenciais quando `search_per_field=True` produz >100 queries totais (cobre o cenário do issue #67 em datasets maiores).
- Mensagem enxuta em uma linha (sem banners ASCII), citando provedor, condições de risco e valores recomendados de \`parallel_requests\` e \`rate_limit_delay\`.
- Documentação atualizada em `docs/guides/web-search.md` e `docs/en/guides/web-search.md` com tabelas de configuração por provedor.
- 10 testes novos em `tests/test_search.py`.

Substitui #72 (criado por agente, ficou desatualizado com a main).

## Test plan
- [x] `uv run pytest` — 257 passed, 5 skipped.
- [x] `uv run pytest tests/test_search.py` — 92 passed.
- [ ] Smoke manual com \`use_search=True\`, \`parallel_requests=20\`, \`search_per_field=True\` para conferir a mensagem emitida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)