### PR TITLE
feat(core): infer text column by common names (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ### Adicionado
 
+- **Inferência automática de `text_column`** (#93): quando `text_column=None` em um DataFrame, a lib agora tenta, em ordem, as colunas `texto`, `text`, `decisao`, `content`, `content_text`. Zero-config para integrar com pipelines `juscraper.cjpg/cjsg → dataframeit` (coluna `decisao`). Warning em caso de ambiguidade; ValueError informativo (listando colunas disponíveis) se nenhum candidato bate. DataFrames de 1 coluna passam a usar essa coluna direto. `text_column=` explícito continua tendo precedência absoluta.
 - **Suporte opcional a Groq** (#94): novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
 - **Aviso de rate limit para busca web** (#67): `dataframeit(...)` agora emite um `UserWarning` quando a combinação de `use_search=True`, `parallel_requests` e `search_per_field` pode exceder o rate limit do provedor de busca (Tavily ou Exa). A mensagem inclui recomendações específicas de `parallel_requests` e `rate_limit_delay`. O aviso também dispara em execuções sequenciais quando o total de queries estimadas (`linhas × campos`) ultrapassa 100.
 - Documentação de rate limits e processamento paralelo em `docs/guides/web-search.md` e `docs/en/guides/web-search.md`, com tabelas de configurações recomendadas por provedor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ### Adicionado
 
-- **Inferência automática de `text_column`** (#93): quando `text_column=None` em um DataFrame, a lib agora tenta, em ordem, as colunas `texto`, `text`, `decisao`, `content`, `content_text`. Zero-config para integrar com pipelines `juscraper.cjpg/cjsg → dataframeit` (coluna `decisao`). Warning em caso de ambiguidade; ValueError informativo (listando colunas disponíveis) se nenhum candidato bate. DataFrames de 1 coluna passam a usar essa coluna direto. `text_column=` explícito continua tendo precedência absoluta.
+- Inferência automática de `text_column` em DataFrames quando `None` (#93): tenta `texto`, `text`, `decisao`, `content`, `content_text` em ordem; DataFrames de 1 coluna usam-na direto.
 - **Suporte opcional a Groq** (#94): novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
 - **Aviso de rate limit para busca web** (#67): `dataframeit(...)` agora emite um `UserWarning` quando a combinação de `use_search=True`, `parallel_requests` e `search_per_field` pode exceder o rate limit do provedor de busca (Tavily ou Exa). A mensagem inclui recomendações específicas de `parallel_requests` e `rate_limit_delay`. O aviso também dispara em execuções sequenciais quando o total de queries estimadas (`linhas × campos`) ultrapassa 100.
 - Documentação de rate limits e processamento paralelo em `docs/guides/web-search.md` e `docs/en/guides/web-search.md`, com tabelas de configurações recomendadas por provedor.

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -42,7 +42,7 @@ def dataframeit(
 | `data` | DataFrame, Series, list, dict | Yes | Data containing texts to process |
 | `questions` | Pydantic BaseModel | Yes | Pydantic model defining fields to extract |
 | `prompt` | str | Yes | Prompt template. Use `{texto}` to position text |
-| `text_column` | str | DataFrame: Yes | Column name with texts. Default: `'texto'` |
+| `text_column` | str | No | Column name with texts. If `None`, tries `texto`, `text`, `decisao`, `content`, `content_text` in order (or the single column if the DataFrame has only one) |
 
 #### Processing
 

--- a/docs/en/reference/llm-reference.md
+++ b/docs/en/reference/llm-reference.md
@@ -34,7 +34,7 @@ result = dataframeit(
     data,                    # DataFrame, Series, list or dict
     questions,               # Pydantic model
     prompt,                  # Prompt template
-    text_column='text',      # Column with texts (required for DataFrame)
+    text_column=None,        # Column with texts (None = automatic inference)
     model='gemini-3-flash-preview',
     provider='google_genai', # 'google_genai', 'openai', 'anthropic'
     resume=True,             # Continue from where it stopped

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -42,7 +42,7 @@ def dataframeit(
 | `data` | DataFrame, Series, list, dict | Sim | Dados contendo os textos a processar |
 | `questions` | Pydantic BaseModel | Sim | Modelo Pydantic definindo campos a extrair |
 | `prompt` | str | Sim | Template do prompt. Use `{texto}` para posicionar o texto |
-| `text_column` | str | DataFrame: Sim | Nome da coluna com textos. Padrão: `'texto'` |
+| `text_column` | str | Não | Nome da coluna com textos. Se `None`, tenta `texto`, `text`, `decisao`, `content`, `content_text` na ordem (ou a única coluna, se o DataFrame tiver apenas uma) |
 
 #### Processamento
 

--- a/docs/reference/llm-reference.md
+++ b/docs/reference/llm-reference.md
@@ -34,7 +34,7 @@ resultado = dataframeit(
     data,                    # DataFrame, Series, list ou dict
     questions,               # Modelo Pydantic
     prompt,                  # Template do prompt
-    text_column='texto',     # Coluna com textos (obrigatório para DataFrame)
+    text_column=None,        # Coluna com textos (None = inferência automática)
     model='gemini-3-flash-preview',
     provider='google_genai', # 'google_genai', 'openai', 'anthropic'
     resume=True,             # Continua de onde parou

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -301,9 +301,10 @@ def dataframeit(
         provider: Provider do LangChain ('google_genai', 'openai', 'anthropic', etc).
         status_column: Coluna para rastrear progresso.
         text_column: Nome da coluna com textos. Se None em um DataFrame, a lib
-                    infere automaticamente dentre TEXT_COLUMN_CANDIDATES
-                    ('texto', 'text', 'decisao', 'content', 'content_text') e
-                    levanta ValueError informativo se nenhuma bate.
+                    infere dentre TEXT_COLUMN_CANDIDATES ('texto', 'text',
+                    'decisao', 'content', 'content_text'); DataFrames com uma
+                    única coluna usam-na direto. Se nenhum candidato bater e o
+                    DataFrame tiver múltiplas colunas, levanta ValueError.
                     Automático para Series/list/dict.
         api_key: Chave API específica.
         max_retries: Número máximo de tentativas.

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -30,6 +30,11 @@ logging.getLogger('httpx').setLevel(logging.WARNING)
 # Chaves de configuração per-field reconhecidas em json_schema_extra
 _FIELD_CONFIG_KEYS = ('prompt', 'prompt_replace', 'prompt_append', 'search_depth', 'max_results')
 
+# Nomes candidatos consultados quando o usuário não passa text_column explicitamente.
+# Ordem: convenção da lib ('texto'), inglês ('text'), juscraper cjpg/cjsg ('decisao'),
+# e convenções comuns de ETL ('content', 'content_text').
+TEXT_COLUMN_CANDIDATES = ('texto', 'text', 'decisao', 'content', 'content_text')
+
 
 # Limites aproximados de requisições por minuto por provedor de busca.
 _SEARCH_PROVIDER_RATE_LIMITS = {
@@ -295,8 +300,11 @@ def dataframeit(
         model: Nome do modelo LLM.
         provider: Provider do LangChain ('google_genai', 'openai', 'anthropic', etc).
         status_column: Coluna para rastrear progresso.
-        text_column: Nome da coluna com textos (obrigatório para DataFrames,
-                    automático para Series/list/dict).
+        text_column: Nome da coluna com textos. Se None em um DataFrame, a lib
+                    infere automaticamente dentre TEXT_COLUMN_CANDIDATES
+                    ('texto', 'text', 'decisao', 'content', 'content_text') e
+                    levanta ValueError informativo se nenhuma bate.
+                    Automático para Series/list/dict.
         api_key: Chave API específica.
         max_retries: Número máximo de tentativas.
         base_delay: Delay base para retry.
@@ -403,11 +411,30 @@ def dataframeit(
     )
 
     if is_dataframe_type:
-        # Para DataFrames, usa 'texto' como padrão se não especificado
         if text_column is None:
-            text_column = 'texto'
+            matches = [c for c in TEXT_COLUMN_CANDIDATES if c in df_pandas.columns]
+            if matches:
+                text_column = matches[0]
+                if len(matches) > 1:
+                    warnings.warn(
+                        f"Múltiplas colunas candidatas encontradas: {matches}. "
+                        f"Usando '{text_column}'. Passe text_column= para suprimir este aviso.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+            elif len(df_pandas.columns) == 1:
+                text_column = df_pandas.columns[0]
+            else:
+                raise ValueError(
+                    f"Nenhuma coluna de texto identificada entre {TEXT_COLUMN_CANDIDATES}. "
+                    f"Colunas disponíveis: {list(df_pandas.columns)}. "
+                    f"Passe text_column= explicitamente."
+                )
         if text_column not in df_pandas.columns:
-            raise ValueError(f"Coluna '{text_column}' não encontrada no DataFrame")
+            raise ValueError(
+                f"Coluna '{text_column}' não encontrada no DataFrame. "
+                f"Colunas disponíveis: {list(df_pandas.columns)}."
+            )
     else:
         # Para Series/list/dict, usa coluna interna
         text_column = DEFAULT_TEXT_COLUMN

--- a/tests/test_text_column_inference.py
+++ b/tests/test_text_column_inference.py
@@ -1,0 +1,105 @@
+"""Testes para inferência de text_column a partir de nomes comuns (#93)."""
+
+import warnings
+import pandas as pd
+import pytest
+from pydantic import BaseModel, Field
+from unittest.mock import patch
+
+
+class _Model(BaseModel):
+    resumo: str = Field(description="resumo curto")
+
+
+def _mock_call_langchain(*args, **kwargs):
+    return {"data": {"resumo": "ok"}, "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}}
+
+
+def test_infers_texto_by_default():
+    """DataFrame com coluna 'texto' continua funcionando sem text_column."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"id": [1], "texto": ["foo"]})
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(df, _Model, "analise")
+    assert result["resumo"].tolist() == ["ok"]
+
+
+def test_infers_decisao_from_juscraper_like_df():
+    """DataFrame com coluna 'decisao' (cjpg/cjsg) é detectado automaticamente."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"cd_processo": ["001"], "decisao": ["texto longo"]})
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(df, _Model, "analise")
+    assert result["resumo"].tolist() == ["ok"]
+
+
+def test_infers_text_english():
+    """DataFrame com coluna 'text' (inglês) é aceito."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"id": [1], "text": ["hello"]})
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(df, _Model, "analise")
+    assert result["resumo"].tolist() == ["ok"]
+
+
+def test_warns_when_multiple_candidates_present():
+    """Quando mais de um candidato está presente, emite UserWarning e usa o primeiro da lista."""
+    from dataframeit.core import dataframeit
+
+    # 'texto' tem precedência sobre 'content' pela ordem de TEXT_COLUMN_CANDIDATES
+    df = pd.DataFrame({"texto": ["foo"], "content": ["bar"]})
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            with warnings.catch_warnings(record=True) as captured:
+                warnings.simplefilter("always")
+                dataframeit(df, _Model, "analise")
+    messages = [str(w.message) for w in captured if issubclass(w.category, UserWarning)]
+    assert any("Múltiplas colunas candidatas" in m for m in messages)
+
+
+def test_raises_when_no_candidate_matches():
+    """Multi-col sem nenhum candidato bater: ValueError informativo."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"id": [1], "payload": ["x"]})
+    with patch("dataframeit.core.validate_provider_dependencies"):
+        with pytest.raises(ValueError) as exc_info:
+            dataframeit(df, _Model, "analise")
+    msg = str(exc_info.value)
+    assert "Nenhuma coluna de texto identificada" in msg
+    assert "text_column=" in msg
+    assert "payload" in msg
+
+
+def test_single_column_df_uses_that_column():
+    """DataFrame com apenas 1 coluna (sem nome canônico) usa-a como texto."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"mensagem": ["hello"]})
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(df, _Model, "analise")
+    assert result["resumo"].tolist() == ["ok"]
+
+
+def test_explicit_text_column_overrides_inference():
+    """text_column= explícito sempre vence a inferência."""
+    from dataframeit.core import dataframeit
+
+    df = pd.DataFrame({"texto": ["ignorado"], "meu_campo": ["usado"]})
+    captured_text = []
+
+    def capture(*args, **kwargs):
+        captured_text.append(args[0])
+        return _mock_call_langchain(*args, **kwargs)
+
+    with patch("dataframeit.core.call_langchain", side_effect=capture):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            dataframeit(df, _Model, "analise", text_column="meu_campo")
+    assert captured_text == ["usado"]


### PR DESCRIPTION
## Summary

- When `text_column` is None on a DataFrame, `dataframeit` now tries these candidates in order and picks the first match: `texto`, `text`, `decisao`, `content`, `content_text`.
- Warn (UserWarning) on ambiguity (more than one candidate present).
- Raise a clear `ValueError` listing available columns if no candidate matches and the DataFrame has more than one column.
- Single-column DataFrames now use that column directly (no more \"Coluna 'texto' não encontrada\" surprise).
- Explicit `text_column=` still wins absolutely.

## Why

Motivated by `juscraper.cjpg/cjsg` pipelines — those return DataFrames whose text column is `decisao`, not `texto`. Today that pipeline either fails (`'texto' not found`) or the user has to remember to pass `text_column='decisao'` every time. Widening the candidate list makes the integration zero-config while keeping the error loud when things are truly ambiguous.

## Test plan

- [x] New `tests/test_text_column_inference.py` with 7 cases: default `texto`, `decisao` from juscraper-like frames, English `text`, ambiguity warning, `ValueError` with no candidate, single-column fallback, explicit override.
- [x] Full suite: 264 passed, 5 skipped.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)