### PR TITLE
feat(io): accept SQL query as input source (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ### Adicionado
 
+- **Leitura de fonte SQL** (#87): `dataframeit()` agora aceita `("SELECT ...", engine)` ou `data="SELECT ..."` + `con=engine`. Internamente usa `pandas.read_sql`, suportando SQLAlchemy engines/Connections, psycopg2 e sqlite3 nativo. A saída continua sendo um DataFrame (não há gravação de volta). Extra opcional disponível via `pip install dataframeit[sql]`.
 - **Suporte opcional a Groq** (#94): novo provider disponível via `pip install dataframeit[groq]`. Use com `provider='groq'` e modelos como `llama-3.3-70b-versatile` ou `llama-3.1-8b-instant`. Requer `GROQ_API_KEY`.
 - **Aviso de rate limit para busca web** (#67): `dataframeit(...)` agora emite um `UserWarning` quando a combinação de `use_search=True`, `parallel_requests` e `search_per_field` pode exceder o rate limit do provedor de busca (Tavily ou Exa). A mensagem inclui recomendações específicas de `parallel_requests` e `rate_limit_delay`. O aviso também dispara em execuções sequenciais quando o total de queries estimadas (`linhas × campos`) ultrapassa 100.
 - Documentação de rate limits e processamento paralelo em `docs/guides/web-search.md` e `docs/en/guides/web-search.md`, com tabelas de configurações recomendadas por provedor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ search-all = [
     "langchain-tavily>=0.1.0",
     "langchain-exa>=0.2.0",
 ]
+sql = [
+    "sqlalchemy>=2.0",
+]
 all = [
     "langchain-google-genai>=2.0.0",
     "langchain-openai>=0.3.0",

--- a/src/dataframeit/core.py
+++ b/src/dataframeit/core.py
@@ -18,6 +18,7 @@ from .utils import (
     DEFAULT_TEXT_COLUMN,
     ORIGINAL_TYPE_PANDAS_DF,
     ORIGINAL_TYPE_POLARS_DF,
+    ORIGINAL_TYPE_SQL,
 )
 from .errors import validate_provider_dependencies, validate_search_dependencies, get_friendly_error_message, is_recoverable_error, is_rate_limit_error
 
@@ -273,6 +274,7 @@ def dataframeit(
     search_depth="basic",
     search_groups: Optional[Dict[str, dict]] = None,
     save_trace: Optional[Union[bool, Literal["full", "minimal"]]] = None,
+    con=None,
 ) -> Any:
     """Processa textos usando LLMs para extrair informações estruturadas.
 
@@ -283,6 +285,8 @@ def dataframeit(
     - polars.Series: Retorna DataFrame polars com resultados
     - list: Retorna lista de dicionários com os resultados
     - dict: Retorna dicionário {chave: {campos extraídos}}
+    - tupla ``(query_sql, conexao)`` ou string SQL + ``con=engine`` (ler via
+      ``pandas.read_sql``; a saída é um DataFrame, não há gravação de volta)
 
     Args:
         data: Dados contendo textos (DataFrame, Series, list ou dict).
@@ -394,12 +398,13 @@ def dataframeit(
         )
 
     # Converter para pandas se necessário
-    df_pandas, conversion_info = to_pandas(data)
+    df_pandas, conversion_info = to_pandas(data, con=con)
 
     # Determinar coluna de texto
     is_dataframe_type = conversion_info.original_type in (
         ORIGINAL_TYPE_PANDAS_DF,
         ORIGINAL_TYPE_POLARS_DF,
+        ORIGINAL_TYPE_SQL,
     )
 
     if is_dataframe_type:

--- a/src/dataframeit/utils.py
+++ b/src/dataframeit/utils.py
@@ -29,6 +29,7 @@ ORIGINAL_TYPE_PANDAS_SERIES = 'pandas_series'
 ORIGINAL_TYPE_POLARS_SERIES = 'polars_series'
 ORIGINAL_TYPE_LIST = 'list'
 ORIGINAL_TYPE_DICT = 'dict'
+ORIGINAL_TYPE_SQL = 'sql_query'
 
 # Coluna padrão usada para dados convertidos
 DEFAULT_TEXT_COLUMN = '_texto'
@@ -101,7 +102,7 @@ def check_dependency(package: str, install_name: str = None):
         )
 
 
-def to_pandas(data) -> Tuple[pd.DataFrame, ConversionInfo]:
+def to_pandas(data, con=None) -> Tuple[pd.DataFrame, ConversionInfo]:
     """Converte dados para pandas DataFrame.
 
     Suporta:
@@ -111,9 +112,12 @@ def to_pandas(data) -> Tuple[pd.DataFrame, ConversionInfo]:
     - polars.Series
     - list (de strings)
     - dict (valores são os textos)
+    - tupla ``(query_sql, conexao)`` ou string SQL + ``con=`` (via pd.read_sql)
 
     Args:
         data: Dados a serem convertidos.
+        con: Conexão SQLAlchemy (engine/Connection) ou string de conexão. Usado
+            somente quando ``data`` é uma string SQL; ignorado nos outros casos.
 
     Returns:
         Tupla (DataFrame pandas, ConversionInfo com metadados da conversão).
@@ -121,6 +125,20 @@ def to_pandas(data) -> Tuple[pd.DataFrame, ConversionInfo]:
     Raises:
         TypeError: Se o tipo não for suportado.
     """
+    # SQL: tupla (query, conexao)
+    if (
+        isinstance(data, tuple)
+        and len(data) == 2
+        and isinstance(data[0], str)
+        and data[1] is not None
+    ):
+        query, connection = data
+        return pd.read_sql(query, connection), ConversionInfo(original_type=ORIGINAL_TYPE_SQL)
+
+    # SQL: query + kwarg con=
+    if isinstance(data, str) and con is not None:
+        return pd.read_sql(data, con), ConversionInfo(original_type=ORIGINAL_TYPE_SQL)
+
     # pandas DataFrame
     if isinstance(data, pd.DataFrame):
         return data, ConversionInfo(original_type=ORIGINAL_TYPE_PANDAS_DF)
@@ -201,8 +219,8 @@ def from_pandas(df: pd.DataFrame, conversion_info: Union[ConversionInfo, bool]) 
             cols_to_drop = [c for c in [status_col, error_col] if c in df.columns]
             df = df.drop(columns=cols_to_drop)
 
-    # pandas DataFrame
-    if conversion_info.original_type == ORIGINAL_TYPE_PANDAS_DF:
+    # pandas DataFrame (inclui fonte SQL — saída é DataFrame, não grava de volta)
+    if conversion_info.original_type in (ORIGINAL_TYPE_PANDAS_DF, ORIGINAL_TYPE_SQL):
         return _reorder_columns(df)
 
     # polars DataFrame

--- a/tests/test_sql_source.py
+++ b/tests/test_sql_source.py
@@ -1,0 +1,90 @@
+"""Testes para leitura a partir de fonte SQL (#87)."""
+
+import sqlite3
+import pandas as pd
+import pytest
+from pydantic import BaseModel, Field
+from unittest.mock import patch
+
+
+class _Model(BaseModel):
+    resumo: str = Field(description="resumo curto")
+
+
+def _mock_call_langchain(*args, **kwargs):
+    return {"data": {"resumo": "ok"}, "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}}
+
+
+@pytest.fixture
+def sqlite_conn():
+    """Conexão SQLite em memória com tabela de fixture."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE decisoes (id INTEGER PRIMARY KEY, texto TEXT)")
+    conn.executemany(
+        "INSERT INTO decisoes (id, texto) VALUES (?, ?)",
+        [(1, "texto um"), (2, "texto dois"), (3, "texto três")],
+    )
+    conn.commit()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_to_pandas_reads_sql_tuple(sqlite_conn):
+    """to_pandas aceita tupla (query, conexao)."""
+    from dataframeit.utils import to_pandas, ORIGINAL_TYPE_SQL
+
+    df, info = to_pandas(("SELECT id, texto FROM decisoes", sqlite_conn))
+    assert info.original_type == ORIGINAL_TYPE_SQL
+    assert len(df) == 3
+    assert set(df.columns) == {"id", "texto"}
+
+
+def test_to_pandas_reads_sql_with_con_kwarg(sqlite_conn):
+    """to_pandas aceita query string + con=."""
+    from dataframeit.utils import to_pandas, ORIGINAL_TYPE_SQL
+
+    df, info = to_pandas("SELECT texto FROM decisoes", con=sqlite_conn)
+    assert info.original_type == ORIGINAL_TYPE_SQL
+    assert df["texto"].tolist() == ["texto um", "texto dois", "texto três"]
+
+
+def test_dataframeit_with_sql_tuple(sqlite_conn):
+    """Pipeline end-to-end: tupla (query, conn) → DataFrame processado."""
+    from dataframeit.core import dataframeit
+
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(
+                ("SELECT id, texto FROM decisoes", sqlite_conn),
+                _Model,
+                "resuma",
+            )
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) == 3
+    assert result["resumo"].tolist() == ["ok", "ok", "ok"]
+
+
+def test_dataframeit_with_sql_con_kwarg(sqlite_conn):
+    """Pipeline end-to-end: query string + con= → DataFrame processado."""
+    from dataframeit.core import dataframeit
+
+    with patch("dataframeit.core.call_langchain", side_effect=_mock_call_langchain):
+        with patch("dataframeit.core.validate_provider_dependencies"):
+            result = dataframeit(
+                "SELECT texto FROM decisoes",
+                _Model,
+                "resuma",
+                con=sqlite_conn,
+            )
+    assert isinstance(result, pd.DataFrame)
+    assert result["resumo"].tolist() == ["ok", "ok", "ok"]
+
+
+def test_plain_string_without_con_still_not_treated_as_sql():
+    """String sem con= não é tratada como SQL — continua caindo no TypeError existente."""
+    from dataframeit.utils import to_pandas
+
+    with pytest.raises(TypeError):
+        to_pandas("SELECT 1")


### PR DESCRIPTION
## Summary

- `dataframeit()` now accepts a SQL query as input via two forms:
  - `dataframeit((\"SELECT id, texto FROM decisoes WHERE ano=2024\", engine), Model, PROMPT)`
  - `dataframeit(\"SELECT ...\", Model, PROMPT, con=engine)`
- Reads with `pandas.read_sql`, so any connection it supports works: SQLAlchemy engines/Connections, psycopg2, native sqlite3.
- Adds `pip install dataframeit[sql]` optional extra (pulls `sqlalchemy>=2.0`). Not required if the user already has `pandas` + their DB driver.

## Scope

Only **reading** from SQL — this is what #87 asks. Writing results back to a table is intentionally out of scope; that interacts with #92 (checkpointing) and deserves a dedicated design pass.

## Test plan

- [x] New `tests/test_sql_source.py` using SQLite in memory: tuple form, `con=` kwarg, full pipeline end-to-end (with mocked LLM), and the negative case (plain string without `con=` is still rejected).
- [x] Full suite: 262 passed, 5 skipped.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)