### PR TITLE
refactor(conditional): derive depends_on from condition dict (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ htmlcov/
 
 # Claude
 .claude/
+.playwright-mcp/
 
 # Project specific
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
-## [0.6.1] - 2026-04-30
+## [0.7.0] - 2026-04-30
 
 ### Alterado
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-30
+
+### Alterado
+
+- `depends_on` é derivado automaticamente de `condition` quando esta é um dict; só precisa ser declarado explicitamente para `condition` callable (#103).
+
+### Removido
+
+- `depends_on` sem `condition` deixa de afetar a ordem de execução (apenas emite warning) (#103).
+
 ## [0.6.0] - 2026-04-20
 
 ### Removido

--- a/docs/examples/conditional-fields.md
+++ b/docs/examples/conditional-fields.md
@@ -1,17 +1,17 @@
 # Campos Condicionais
 
-A partir da versão 0.6.0, o DataFrameIt suporta execução condicional de campos quando usando `search_per_field=True`. Isso permite que você:
+O DataFrameIt suporta execução condicional de campos quando usando `search_per_field=True`. Isso permite que você:
 
-1. **Controle a ordem de execução** dos campos através de dependências
-2. **Execute campos condicionalmente** baseado em valores de outros campos
-3. **Acesse campos aninhados** nas condições
+1. **Execute campos condicionalmente** baseado em valores de outros campos
+2. **Acesse campos aninhados** nas condições
+3. **Controle a ordem de execução** — derivada automaticamente da condição
 
 ## Configuração Básica
 
-Use as seguintes chaves no `json_schema_extra` de cada campo:
+Use a chave `condition` no `json_schema_extra` de cada campo:
 
-- `depends_on`: Lista de campos que devem ser processados antes deste campo
-- `condition`: Condição para executar o campo (se não satisfeita, o campo é pulado)
+- `condition` (dict): condição para executar o campo. A dependência (e portanto a ordem de execução) é **derivada automaticamente** do campo referenciado em `condition['field']`.
+- `condition` (callable): função que recebe os campos já processados e retorna bool. Para que a ordem seja respeitada, declare os campos lidos via `depends_on`.
 
 ## Exemplo 1: Pessoa Física vs Jurídica
 
@@ -29,7 +29,6 @@ class PessoaInfo(BaseModel):
     cpf: str = Field(
         description="CPF da pessoa física",
         json_schema_extra={
-            'depends_on': ['tipo'],
             'condition': {'field': 'tipo', 'equals': 'pf'}
         }
     )
@@ -37,7 +36,6 @@ class PessoaInfo(BaseModel):
     cnpj: str = Field(
         description="CNPJ da pessoa jurídica",
         json_schema_extra={
-            'depends_on': ['tipo'],
             'condition': {'field': 'tipo', 'equals': 'pj'}
         }
     )
@@ -45,7 +43,6 @@ class PessoaInfo(BaseModel):
     razao_social: str = Field(
         description="Razão social da empresa",
         json_schema_extra={
-            'depends_on': ['tipo'],
             'condition': {'field': 'tipo', 'equals': 'pj'}
         }
     )
@@ -72,9 +69,9 @@ print(result)
 # Para a segunda linha: tipo='pj', cpf=None, cnpj='12.345.678/0001-90', razao_social='Empresa XYZ LTDA'
 ```
 
-## Exemplo 2: Campos Aninhados
+## Exemplo 2: Campos Encadeados
 
-Este exemplo mostra como usar condições com campos aninhados:
+Este exemplo mostra como encadear condições em sequência:
 
 ```python
 class EnderecoInfo(BaseModel):
@@ -83,7 +80,6 @@ class EnderecoInfo(BaseModel):
     estado: str = Field(
         description="Estado (apenas para Brasil)",
         json_schema_extra={
-            'depends_on': ['pais'],
             'condition': {'field': 'pais', 'equals': 'Brasil'}
         }
     )
@@ -91,7 +87,6 @@ class EnderecoInfo(BaseModel):
     cep: str = Field(
         description="CEP (apenas para Brasil)",
         json_schema_extra={
-            'depends_on': ['estado'],
             'condition': {'field': 'estado', 'exists': True}
         }
     )
@@ -99,15 +94,14 @@ class EnderecoInfo(BaseModel):
     zip_code: str = Field(
         description="ZIP Code (apenas para outros países)",
         json_schema_extra={
-            'depends_on': ['pais'],
             'condition': {'field': 'pais', 'not_equals': 'Brasil'}
         }
     )
 ```
 
-## Exemplo 3: Múltiplas Dependências
+## Exemplo 3: Condição Callable com Múltiplas Dependências
 
-Campos podem depender de múltiplos outros campos:
+Quando a condição combina vários campos, use um callable e declare os campos lidos via `depends_on`:
 
 ```python
 class PedidoInfo(BaseModel):
@@ -123,13 +117,6 @@ class PedidoInfo(BaseModel):
                 data.get('tipo_cliente') == 'vip' and
                 data.get('valor_pedido', 0) > 1000
             )
-        }
-    )
-
-    frete_gratis: bool = Field(
-        description="Se o frete é grátis",
-        json_schema_extra={
-            'depends_on': ['desconto'],
         }
     )
 ```
@@ -170,9 +157,11 @@ Para condições mais complexas, use uma função:
 }
 ```
 
+Lembre-se de declarar `depends_on` com os campos lidos pelo lambda — sem isso, a ordem de execução não é garantida.
+
 ## Campos Aninhados em Condições
 
-Você pode acessar campos aninhados usando notação de ponto:
+Você pode acessar campos aninhados usando notação de ponto. A dependência derivada é o campo raiz:
 
 ```python
 class ProdutoInfo(BaseModel):
@@ -181,7 +170,6 @@ class ProdutoInfo(BaseModel):
     taxa_entrega: float = Field(
         description="Taxa de entrega",
         json_schema_extra={
-            'depends_on': ['endereco'],
             'condition': {'field': 'endereco.cidade', 'in': ['São Paulo', 'Rio de Janeiro']}
         }
     )
@@ -189,17 +177,17 @@ class ProdutoInfo(BaseModel):
 
 ## Ordem de Execução
 
-O DataFrameIt automaticamente determina a ordem correta de execução dos campos baseado nas dependências declaradas. Por exemplo:
+O DataFrameIt deriva a ordem automaticamente do campo referenciado em cada `condition`:
 
 ```python
-class ModeloComplexo(BaseModel):
+class ModeloEncadeado(BaseModel):
     a: str
-    b: str = Field(json_schema_extra={'depends_on': ['a']})
-    c: str = Field(json_schema_extra={'depends_on': ['a', 'b']})
-    d: str = Field(json_schema_extra={'depends_on': ['c']})
+    b: str = Field(json_schema_extra={'condition': {'field': 'a', 'equals': 'x'}})
+    c: str = Field(json_schema_extra={'condition': {'field': 'b', 'equals': 'y'}})
+    d: str = Field(json_schema_extra={'condition': {'field': 'c', 'equals': 'z'}})
 ```
 
-A ordem de execução será: `a → b → c → d`
+A ordem de execução será: `a → b → c → d`.
 
 ## Detecção de Dependências Circulares
 
@@ -207,8 +195,8 @@ O sistema detecta automaticamente dependências circulares e gera um erro:
 
 ```python
 class ModeloInvalido(BaseModel):
-    a: str = Field(json_schema_extra={'depends_on': ['b']})
-    b: str = Field(json_schema_extra={'depends_on': ['a']})
+    a: str = Field(json_schema_extra={'condition': {'field': 'b', 'equals': 'x'}})
+    b: str = Field(json_schema_extra={'condition': {'field': 'a', 'equals': 'x'}})
 
 # ValueError: Dependências circulares detectadas: a -> b -> a
 ```
@@ -247,7 +235,6 @@ class InfoCompleta(BaseModel):
 
     detalhes_pf: str = Field(
         json_schema_extra={
-            'depends_on': ['tipo'],
             'condition': {'field': 'tipo', 'equals': 'pf'},
             'search_depth': 'advanced',  # Busca mais profunda
             'max_results': 10,  # Mais resultados

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dataframeit"
-version = "0.6.1"
+version = "0.7.0"
 description = "Enriqueça DataFrames com análises de texto usando LLMs. Extraia informações estruturadas de textos com Pydantic."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dataframeit"
-version = "0.6.0"
+version = "0.6.1"
 description = "Enriqueça DataFrames com análises de texto usando LLMs. Extraia informações estruturadas de textos com Pydantic."
 readme = "README.md"
 license = "MIT"

--- a/src/dataframeit/agent.py
+++ b/src/dataframeit/agent.py
@@ -31,7 +31,9 @@ def _get_field_config(extra: dict) -> dict:
 
     Returns:
         Dicionário com configurações extraídas (prompt, prompt_append,
-        search_depth, max_results, depends_on, condition).
+        search_depth, max_results, depends_on, condition). `depends_on`
+        é normalmente derivado automaticamente de `condition` (quando
+        dict) — só precisa ser declarado para `condition` callable.
     """
     return {
         'prompt': extra.get('prompt') or extra.get('prompt_replace'),
@@ -476,9 +478,10 @@ def call_agent_per_field(
     Útil quando o modelo tem muitos campos e um único contexto ficaria
     sobrecarregado com informações de múltiplas buscas.
 
-    Suporta execução condicional de campos baseada em:
-    - depends_on: lista de campos que devem ser processados primeiro
-    - condition: condição para executar o campo (baseado em valores de outros campos)
+    Suporta execução condicional via `condition` no json_schema_extra dos
+    campos. A ordem de processamento é derivada automaticamente do campo
+    referenciado em `condition` (quando dict). Para `condition` callable,
+    declare explicitamente os campos lidos via `depends_on`.
 
     Suporta campos aninhados em List[Model], Optional[Model], etc.
     Para campos List[Model] com configuração de busca interna:

--- a/src/dataframeit/conditional.py
+++ b/src/dataframeit/conditional.py
@@ -292,9 +292,9 @@ def _resolve_depends_on(field_name: str, config: dict) -> List[str]:
     """Resolve as dependências de um campo a partir de sua configuração.
 
     Regras:
-    1. `depends_on` explícito sempre vence (mas é ignorado se não houver `condition`).
-    2. Sem `depends_on` explícito e com `condition` dict, deriva o campo raiz de `condition['field']`.
-    3. Caso contrário (callable sem depends_on, sem condition, etc.), retorna lista vazia.
+    1. Sem `condition`, `depends_on` é ignorado (com warning) — sem condition, ordem não afeta o resultado.
+    2. Com `condition` dict, a dep do campo raiz de `condition['field']` é unida ao `depends_on` explícito.
+    3. Com `condition` callable sem `depends_on`, retorna lista vazia (com warning).
     """
     explicit = config.get('depends_on') or []
     if isinstance(explicit, str):
@@ -304,21 +304,31 @@ def _resolve_depends_on(field_name: str, config: dict) -> List[str]:
 
     condition = config.get('condition')
 
-    if explicit:
-        if not condition:
+    if condition is None:
+        if explicit:
             logger.warning(
                 f"Campo '{field_name}' tem 'depends_on' mas não tem 'condition' — "
                 f"depends_on será ignorado (sem condition, ordem não afeta o resultado)."
             )
-            return []
-        return explicit
+        return []
 
+    derived: List[str] = []
     if isinstance(condition, dict):
         field_path = condition.get('field')
         if field_path:
-            return [field_path.split('.')[0]]
+            derived = [field_path.split('.')[0]]
+    elif callable(condition) and not explicit:
+        logger.warning(
+            f"Campo '{field_name}' tem 'condition' callable sem 'depends_on' — "
+            f"a ordem de execução não é garantida. Declare 'depends_on' com os campos "
+            f"lidos pela função."
+        )
 
-    return []
+    result = list(explicit)
+    for dep in derived:
+        if dep not in result:
+            result.append(dep)
+    return result
 
 
 def get_field_execution_order(

--- a/src/dataframeit/conditional.py
+++ b/src/dataframeit/conditional.py
@@ -288,15 +288,52 @@ def topological_sort(dependencies: Dict[str, List[str]]) -> List[str]:
     return result
 
 
+def _resolve_depends_on(field_name: str, config: dict) -> List[str]:
+    """Resolve as dependências de um campo a partir de sua configuração.
+
+    Regras:
+    1. `depends_on` explícito sempre vence (mas é ignorado se não houver `condition`).
+    2. Sem `depends_on` explícito e com `condition` dict, deriva o campo raiz de `condition['field']`.
+    3. Caso contrário (callable sem depends_on, sem condition, etc.), retorna lista vazia.
+    """
+    explicit = config.get('depends_on') or []
+    if isinstance(explicit, str):
+        explicit = [explicit]
+    elif not isinstance(explicit, list):
+        explicit = []
+
+    condition = config.get('condition')
+
+    if explicit:
+        if not condition:
+            logger.warning(
+                f"Campo '{field_name}' tem 'depends_on' mas não tem 'condition' — "
+                f"depends_on será ignorado (sem condition, ordem não afeta o resultado)."
+            )
+            return []
+        return explicit
+
+    if isinstance(condition, dict):
+        field_path = condition.get('field')
+        if field_path:
+            return [field_path.split('.')[0]]
+
+    return []
+
+
 def get_field_execution_order(
     pydantic_model,
     field_configs: Dict[str, dict]
 ) -> Tuple[List[str], Dict[str, List[str]]]:
     """Determina ordem de execução dos campos baseado em dependências.
 
+    Dependências são derivadas automaticamente de `condition` (quando dict)
+    ou declaradas explicitamente via `depends_on` (necessário apenas para
+    `condition` callable).
+
     Args:
         pydantic_model: Modelo Pydantic.
-        field_configs: Dict mapeando campo -> config (com 'depends_on').
+        field_configs: Dict mapeando campo -> config (com 'condition' e/ou 'depends_on').
 
     Returns:
         Tupla (ordem_de_execução, mapa_de_dependências).
@@ -307,18 +344,10 @@ def get_field_execution_order(
     all_fields = set(pydantic_model.model_fields.keys())
     dependencies = {}
 
-    # Construir mapa de dependências
     for field_name in all_fields:
         config = field_configs.get(field_name, {})
-        depends_on = config.get('depends_on', [])
+        depends_on = _resolve_depends_on(field_name, config)
 
-        # Normalizar para lista
-        if isinstance(depends_on, str):
-            depends_on = [depends_on]
-        elif not isinstance(depends_on, list):
-            depends_on = []
-
-        # Verificar se dependências existem
         missing = check_dependencies_exist(field_name, depends_on, all_fields)
         if missing:
             raise ValueError(
@@ -327,7 +356,6 @@ def get_field_execution_order(
 
         dependencies[field_name] = depends_on
 
-    # Ordenar topologicamente
     ordered = topological_sort(dependencies)
 
     return ordered, dependencies

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -325,8 +325,8 @@ class TestGetFieldExecutionOrder:
         assert deps['cpf'] == ['tipo']
         assert order.index('tipo') < order.index('cpf')
 
-    def test_explicit_depends_on_overrides_condition(self):
-        """Testa que depends_on explícito vence sobre derivação automática."""
+    def test_explicit_depends_on_unions_with_condition(self):
+        """Testa que depends_on explícito é unido com a derivação automática."""
         class M(BaseModel):
             a: str
             b: str
@@ -347,6 +347,30 @@ class TestGetFieldExecutionOrder:
         assert deps['c'] == ['a', 'b']
         assert order.index('a') < order.index('c')
         assert order.index('b') < order.index('c')
+
+    def test_explicit_depends_on_unions_with_condition_field(self):
+        """Testa união quando o explícito não inclui o campo da condition."""
+        class M(BaseModel):
+            tipo: str
+            x: str
+            c: str = Field(json_schema_extra={
+                'depends_on': ['x'],
+                'condition': {'field': 'tipo', 'equals': 'pf'},
+            })
+
+        configs = {
+            'tipo': {},
+            'x': {},
+            'c': {
+                'depends_on': ['x'],
+                'condition': {'field': 'tipo', 'equals': 'pf'},
+            },
+        }
+        order, deps = get_field_execution_order(M, configs)
+        assert set(deps['c']) == {'x', 'tipo'}
+        assert deps['c'][0] == 'x'  # explícito preservado primeiro
+        assert order.index('x') < order.index('c')
+        assert order.index('tipo') < order.index('c')
 
     def test_nested_condition_field_uses_root(self):
         """Testa que campo aninhado em condition ('endereco.cidade') resolve para raiz ('endereco')."""
@@ -396,6 +420,53 @@ class TestGetFieldExecutionOrder:
         order, deps = get_field_execution_order(M, configs)
         assert deps['b'] == []
         assert set(order) == {'a', 'b'}
+
+    def test_callable_condition_without_depends_on_emits_warning(self, caplog):
+        """Testa que callable sem depends_on emite warning."""
+        import logging
+
+        class M(BaseModel):
+            a: str
+            b: str = Field(json_schema_extra={
+                'condition': lambda data: bool(data.get('a'))
+            })
+
+        configs = {
+            'a': {},
+            'b': {'condition': lambda data: bool(data.get('a'))},
+        }
+        with caplog.at_level(logging.WARNING, logger='dataframeit.conditional'):
+            get_field_execution_order(M, configs)
+        assert any(
+            "callable" in rec.message and "depends_on" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_callable_condition_with_depends_on_no_warning(self, caplog):
+        """Testa que callable com depends_on não emite warning."""
+        import logging
+
+        class M(BaseModel):
+            a: str
+            b: str = Field(json_schema_extra={
+                'depends_on': ['a'],
+                'condition': lambda data: bool(data.get('a')),
+            })
+
+        configs = {
+            'a': {},
+            'b': {
+                'depends_on': ['a'],
+                'condition': lambda data: bool(data.get('a')),
+            },
+        }
+        with caplog.at_level(logging.WARNING, logger='dataframeit.conditional'):
+            order, deps = get_field_execution_order(M, configs)
+        assert deps['b'] == ['a']
+        assert not any(
+            "callable" in rec.message and "depends_on" in rec.message
+            for rec in caplog.records
+        )
 
 
 class TestShouldSkipField:

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -242,32 +242,39 @@ class TestGetFieldExecutionOrder:
     """Testes para get_field_execution_order."""
 
     def test_simple_order(self):
-        """Testa ordem de execução simples."""
+        """Testa ordem de execução simples (depends_on derivado de condition dict)."""
         class SimpleModel(BaseModel):
             a: str
-            b: str = Field(json_schema_extra={'depends_on': ['a']})
+            b: str = Field(json_schema_extra={'condition': {'field': 'a', 'equals': 'x'}})
 
         field_configs = {
             'a': {},
-            'b': {'depends_on': ['a']},
+            'b': {'condition': {'field': 'a', 'equals': 'x'}},
         }
 
         order, deps = get_field_execution_order(SimpleModel, field_configs)
         assert order.index('a') < order.index('b')
+        assert deps['b'] == ['a']
 
     def test_complex_order(self):
-        """Testa ordem de execução complexa."""
+        """Testa ordem de execução complexa via auto-derivação."""
         class ComplexModel(BaseModel):
             tipo: str
-            cpf: str = Field(json_schema_extra={'depends_on': ['tipo']})
-            cnpj: str = Field(json_schema_extra={'depends_on': ['tipo']})
-            validacao: str = Field(json_schema_extra={'depends_on': ['cpf', 'cnpj']})
+            cpf: str = Field(json_schema_extra={'condition': {'field': 'tipo', 'equals': 'pf'}})
+            cnpj: str = Field(json_schema_extra={'condition': {'field': 'tipo', 'equals': 'pj'}})
+            validacao: str = Field(json_schema_extra={
+                'depends_on': ['cpf', 'cnpj'],
+                'condition': lambda data: bool(data.get('cpf') or data.get('cnpj')),
+            })
 
         field_configs = {
             'tipo': {},
-            'cpf': {'depends_on': ['tipo']},
-            'cnpj': {'depends_on': ['tipo']},
-            'validacao': {'depends_on': ['cpf', 'cnpj']},
+            'cpf': {'condition': {'field': 'tipo', 'equals': 'pf'}},
+            'cnpj': {'condition': {'field': 'tipo', 'equals': 'pj'}},
+            'validacao': {
+                'depends_on': ['cpf', 'cnpj'],
+                'condition': lambda data: bool(data.get('cpf') or data.get('cnpj')),
+            },
         }
 
         order, deps = get_field_execution_order(ComplexModel, field_configs)
@@ -277,30 +284,118 @@ class TestGetFieldExecutionOrder:
         assert order.index('cnpj') < order.index('validacao')
 
     def test_missing_dependency_raises(self):
-        """Testa que dependência inexistente levanta erro."""
+        """Testa que dependência inexistente levanta erro (via condition dict)."""
         class ModelWithInvalidDep(BaseModel):
-            a: str = Field(json_schema_extra={'depends_on': ['nonexistent']})
+            a: str = Field(json_schema_extra={
+                'condition': {'field': 'nonexistent', 'equals': 'x'}
+            })
 
         field_configs = {
-            'a': {'depends_on': ['nonexistent']},
+            'a': {'condition': {'field': 'nonexistent', 'equals': 'x'}},
         }
 
         with pytest.raises(ValueError, match="depende de campos inexistentes"):
             get_field_execution_order(ModelWithInvalidDep, field_configs)
 
     def test_circular_dependency_raises(self):
-        """Testa que dependência circular levanta erro."""
+        """Testa que dependência circular levanta erro (via condition dict)."""
         class ModelWithCircular(BaseModel):
-            a: str = Field(json_schema_extra={'depends_on': ['b']})
-            b: str = Field(json_schema_extra={'depends_on': ['a']})
+            a: str = Field(json_schema_extra={'condition': {'field': 'b', 'equals': 'x'}})
+            b: str = Field(json_schema_extra={'condition': {'field': 'a', 'equals': 'x'}})
 
         field_configs = {
-            'a': {'depends_on': ['b']},
-            'b': {'depends_on': ['a']},
+            'a': {'condition': {'field': 'b', 'equals': 'x'}},
+            'b': {'condition': {'field': 'a', 'equals': 'x'}},
         }
 
         with pytest.raises(ValueError, match="Dependências circulares"):
             get_field_execution_order(ModelWithCircular, field_configs)
+
+    def test_auto_derive_from_condition_dict(self):
+        """Testa que condition dict deriva depends_on automaticamente."""
+        class M(BaseModel):
+            tipo: str
+            cpf: str = Field(json_schema_extra={'condition': {'field': 'tipo', 'equals': 'pf'}})
+
+        configs = {
+            'tipo': {},
+            'cpf': {'condition': {'field': 'tipo', 'equals': 'pf'}},
+        }
+        order, deps = get_field_execution_order(M, configs)
+        assert deps['cpf'] == ['tipo']
+        assert order.index('tipo') < order.index('cpf')
+
+    def test_explicit_depends_on_overrides_condition(self):
+        """Testa que depends_on explícito vence sobre derivação automática."""
+        class M(BaseModel):
+            a: str
+            b: str
+            c: str = Field(json_schema_extra={
+                'depends_on': ['a', 'b'],
+                'condition': {'field': 'a', 'equals': 'x'},
+            })
+
+        configs = {
+            'a': {},
+            'b': {},
+            'c': {
+                'depends_on': ['a', 'b'],
+                'condition': {'field': 'a', 'equals': 'x'},
+            },
+        }
+        order, deps = get_field_execution_order(M, configs)
+        assert deps['c'] == ['a', 'b']
+        assert order.index('a') < order.index('c')
+        assert order.index('b') < order.index('c')
+
+    def test_nested_condition_field_uses_root(self):
+        """Testa que campo aninhado em condition ('endereco.cidade') resolve para raiz ('endereco')."""
+        class M(BaseModel):
+            endereco: dict
+            taxa: float = Field(json_schema_extra={
+                'condition': {'field': 'endereco.cidade', 'equals': 'SP'}
+            })
+
+        configs = {
+            'endereco': {},
+            'taxa': {'condition': {'field': 'endereco.cidade', 'equals': 'SP'}},
+        }
+        order, deps = get_field_execution_order(M, configs)
+        assert deps['taxa'] == ['endereco']
+        assert order.index('endereco') < order.index('taxa')
+
+    def test_depends_on_without_condition_emits_warning(self, caplog):
+        """Testa que depends_on sem condition emite warning e é ignorado."""
+        import logging
+
+        class M(BaseModel):
+            a: str
+            b: str = Field(json_schema_extra={'depends_on': ['a']})
+
+        configs = {
+            'a': {},
+            'b': {'depends_on': ['a']},
+        }
+        with caplog.at_level(logging.WARNING, logger='dataframeit.conditional'):
+            order, deps = get_field_execution_order(M, configs)
+        assert deps['b'] == []
+        assert any("depends_on" in rec.message and "condition" in rec.message for rec in caplog.records)
+
+    def test_callable_condition_without_depends_on_has_no_deps(self):
+        """Testa que callable sem depends_on não impõe ordem (não levanta erro)."""
+        class M(BaseModel):
+            a: str
+            b: str = Field(json_schema_extra={
+                'condition': lambda data: bool(data.get('a'))
+            })
+
+        configs = {
+            'a': {},
+            'b': {'condition': lambda data: bool(data.get('a'))},
+        }
+        order, deps = get_field_execution_order(M, configs)
+        assert deps['b'] == []
+        assert set(order) == {'a', 'b'}
 
 
 class TestShouldSkipField:


### PR DESCRIPTION
## Summary
- `depends_on` agora é derivado automaticamente do campo raiz de `condition['field']` quando `condition` é dict — só precisa ser declarado explicitamente para `condition` callable.
- `depends_on` sem `condition` deixa de afetar a ordem de execução (apenas emite warning); a ordem só importava via `combined_data`, que só é lido por `condition`.
- Bump `0.6.0` → `0.6.1`. Closes #103.

## Test plan
- [x] `uv run pytest tests/test_conditional.py -v` (43/43 passam, incluindo 5 novos: auto-derivação, override explícito, campo aninhado, warning sem condition, callable sem deps)
- [x] `uv run pytest` (294/294)
- [x] Sanity-check no REPL com modelo PF/PJ sem `depends_on` — ordem e dependências corretas

🤖 Generated with [Claude Code](https://claude.com/claude-code)