### PR TITLE
feat(providers): LLMs em regiões do Brasil + mensagens de erro p/ providers cloud (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-01
+
+### Adicionado
+
+- Receitas para usar LLMs hospedados em São Paulo via Vertex AI (`southamerica-east1`), AWS Bedrock (`sa-east-1`) e Azure OpenAI (Brazil South) em `docs/guides/providers.md` (#102).
+
+### Corrigido
+
+- Inferência de pacote/env var em `errors.py` para `google_vertexai`, `bedrock`, `bedrock_converse` e `azure_openai`: mensagens de erro agora indicam o pacote correto (`langchain-aws`, `langchain-google-vertexai`, `langchain-openai`) e, para providers com auth via SDK, orientam configuração de credenciais em vez de uma API key inexistente (#102).
+
 ## [0.7.0] - 2026-04-30
 
 ### Alterado

--- a/docs/en/guides/providers.md
+++ b/docs/en/guides/providers.md
@@ -277,6 +277,8 @@ result = dataframeit(
 
 Available model IDs in `sa-east-1` change — check the Bedrock console first. For cross-region inference, use the `us.` prefix (e.g. `us.anthropic.claude-...`) and set `region_name` to whatever your account has enabled.
 
+For the legacy Bedrock API (non-converse), switch to `provider='bedrock'` keeping the same `model_kwargs`. The newer API (`bedrock_converse`) is recommended for new projects.
+
 ### Azure OpenAI (Brazil South)
 
 ```bash
@@ -297,6 +299,8 @@ result = dataframeit(
 ```
 
 The region is encoded in `AZURE_OPENAI_ENDPOINT` — provision the resource in "Brazil South" via the Azure portal.
+
+The API version (`OPENAI_API_VERSION`) changes often. Check the latest stable version at [aka.ms/azure-openai-api-versions](https://aka.ms/azure-openai-api-versions).
 
 ## Price Comparison (Approximate - 2025)
 

--- a/docs/en/guides/providers.md
+++ b/docs/en/guides/providers.md
@@ -212,6 +212,92 @@ result = dataframeit(
 )
 ```
 
+## Brazilian region (São Paulo)
+
+The providers above use global public endpoints. To serve from Brazil — for latency, data residency or regulatory reasons — use one of the three options below. In all of them, `dataframeit` forwards `model_kwargs` straight to LangChain.
+
+### Vertex AI (Gemini in `southamerica-east1`)
+
+Two variants. The first one needs no extra package install:
+
+```python
+# Variant A: uses langchain-google-genai (already a dep of provider 'google_genai')
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='google_genai',
+    model='gemini-2.5-flash',
+    model_kwargs={
+        'vertexai': True,
+        'project': '<gcp-project-id>',
+        'location': 'southamerica-east1',
+    },
+)
+```
+
+```python
+# Variant B: uses langchain-google-vertexai (dedicated provider)
+# pip install langchain-google-vertexai
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='google_vertexai',
+    model='gemini-2.5-flash',
+    model_kwargs={
+        'project': '<gcp-project-id>',
+        'location': 'southamerica-east1',
+    },
+)
+```
+
+Authentication (any variant):
+
+```bash
+gcloud auth application-default login
+# OR
+export GOOGLE_APPLICATION_CREDENTIALS=/path/service-account.json
+```
+
+### AWS Bedrock (`sa-east-1`)
+
+```bash
+pip install langchain-aws
+aws configure  # or export AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='bedrock_converse',
+    model='anthropic.claude-3-5-sonnet-20240620-v1:0',
+    model_kwargs={'region_name': 'sa-east-1'},
+)
+```
+
+Available model IDs in `sa-east-1` change — check the Bedrock console first. For cross-region inference, use the `us.` prefix (e.g. `us.anthropic.claude-...`) and set `region_name` to whatever your account has enabled.
+
+### Azure OpenAI (Brazil South)
+
+```bash
+pip install langchain-openai
+export AZURE_OPENAI_API_KEY="your-key"
+export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com/"
+export OPENAI_API_VERSION="2025-03-01-preview"
+```
+
+```python
+result = dataframeit(
+    df, Model, PROMPT,
+    text_column='text',
+    provider='azure_openai',
+    model='gpt-4o',  # or the deployment name
+    model_kwargs={'azure_deployment': '<deployment-name>'},
+)
+```
+
+The region is encoded in `AZURE_OPENAI_ENDPOINT` — provision the resource in "Brazil South" via the Azure portal.
+
 ## Price Comparison (Approximate - 2025)
 
 | Provider | Model | Input (1M tokens) | Output (1M tokens) |

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -201,6 +201,88 @@ resultado = dataframeit(
 )
 ```
 
+## Servidor no Brasil (São Paulo)
+
+Os providers acima usam endpoints públicos globais. Para servir do Brasil — útil por latência, residência de dados ou exigência regulatória — use um dos três caminhos abaixo. Em todos eles, o `dataframeit` repassa o que vier em `model_kwargs` direto para o LangChain.
+
+### Vertex AI (Gemini em `southamerica-east1`)
+
+Duas variantes. A primeira não exige instalar pacote novo:
+
+```python
+# Variante A: usa langchain-google-genai (já é dep do provider 'google_genai')
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='google_genai',
+    model='gemini-2.5-flash',
+    model_kwargs={
+        'vertexai': True,
+        'project': '<id-do-projeto-gcp>',
+        'location': 'southamerica-east1',
+    },
+)
+```
+
+```python
+# Variante B: usa langchain-google-vertexai (provider dedicado)
+# pip install langchain-google-vertexai
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='google_vertexai',
+    model='gemini-2.5-flash',
+    model_kwargs={
+        'project': '<id-do-projeto-gcp>',
+        'location': 'southamerica-east1',
+    },
+)
+```
+
+Autenticação (qualquer variante):
+
+```bash
+gcloud auth application-default login
+# OU
+export GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json
+```
+
+### AWS Bedrock (`sa-east-1`)
+
+```bash
+pip install langchain-aws
+aws configure  # ou exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='bedrock_converse',
+    model='anthropic.claude-3-5-sonnet-20240620-v1:0',
+    model_kwargs={'region_name': 'sa-east-1'},
+)
+```
+
+Os IDs de modelo disponíveis em `sa-east-1` mudam — confira o console Bedrock antes. Para inferência cross-region, use o prefixo `us.` (ex.: `us.anthropic.claude-...`) e ajuste `region_name` ao que sua conta tiver habilitado.
+
+### Azure OpenAI (Brazil South)
+
+```bash
+pip install langchain-openai
+export AZURE_OPENAI_API_KEY="sua-chave"
+export AZURE_OPENAI_ENDPOINT="https://<seu-recurso>.openai.azure.com/"
+export OPENAI_API_VERSION="2025-03-01-preview"
+```
+
+```python
+resultado = dataframeit(
+    df, Model, PROMPT,
+    provider='azure_openai',
+    model='gpt-4o',  # ou o nome do deployment
+    model_kwargs={'azure_deployment': '<nome-do-deployment>'},
+)
+```
+
+A região é codificada no `AZURE_OPENAI_ENDPOINT` — provisione o recurso em "Brazil South" no portal Azure.
+
 ## Comparação de Preços (Aproximado - 2025)
 
 | Provider | Modelo | Input (1M tokens) | Output (1M tokens) |

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -263,6 +263,8 @@ resultado = dataframeit(
 
 Os IDs de modelo disponíveis em `sa-east-1` mudam — confira o console Bedrock antes. Para inferência cross-region, use o prefixo `us.` (ex.: `us.anthropic.claude-...`) e ajuste `region_name` ao que sua conta tiver habilitado.
 
+Para a API Bedrock legada (não-converse), troque por `provider='bedrock'` mantendo o mesmo `model_kwargs`. A nova API (`bedrock_converse`) é recomendada para novos projetos.
+
 ### Azure OpenAI (Brazil South)
 
 ```bash
@@ -282,6 +284,8 @@ resultado = dataframeit(
 ```
 
 A região é codificada no `AZURE_OPENAI_ENDPOINT` — provisione o recurso em "Brazil South" no portal Azure.
+
+A versão da API (`OPENAI_API_VERSION`) muda com frequência. Confira a versão estável mais recente em [aka.ms/azure-openai-api-versions](https://aka.ms/azure-openai-api-versions).
 
 ## Comparação de Preços (Aproximado - 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dataframeit"
-version = "0.7.0"
+version = "0.7.1"
 description = "Enriqueça DataFrames com análises de texto usando LLMs. Extraia informações estruturadas de textos com Pydantic."
 readme = "README.md"
 license = "MIT"

--- a/src/dataframeit/errors.py
+++ b/src/dataframeit/errors.py
@@ -57,6 +57,55 @@ NON_RECOVERABLE_ERRORS = (
 )
 
 
+# Providers cuja heurística simples (langchain_{provider} + {PROVIDER}_API_KEY) não bate com a realidade.
+# env_var=None indica auth por SDK (ADC, AWS creds), não por API key.
+_PROVIDER_OVERRIDES = {
+    'google_vertexai': {
+        'package': 'langchain_google_vertexai',
+        'install': 'langchain-google-vertexai',
+        'env_var': None,
+        'name': 'Google Vertex AI',
+        'auth_hint': (
+            'gcloud auth application-default login\n'
+            'OU exporte GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json'
+        ),
+    },
+    'bedrock': {
+        'package': 'langchain_aws',
+        'install': 'langchain-aws',
+        'env_var': None,
+        'name': 'AWS Bedrock',
+        'auth_hint': (
+            'aws configure\n'
+            'OU exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY '
+            '(opcional: AWS_SESSION_TOKEN, AWS_REGION)'
+        ),
+    },
+    'bedrock_converse': {
+        'package': 'langchain_aws',
+        'install': 'langchain-aws',
+        'env_var': None,
+        'name': 'AWS Bedrock (Converse)',
+        'auth_hint': (
+            'aws configure\n'
+            'OU exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY '
+            '(opcional: AWS_SESSION_TOKEN, AWS_REGION)'
+        ),
+    },
+    'azure_openai': {
+        'package': 'langchain_openai',
+        'install': 'langchain-openai',
+        'env_var': 'AZURE_OPENAI_API_KEY',
+        'name': 'Azure OpenAI',
+        'auth_hint': (
+            'export AZURE_OPENAI_API_KEY="sua-chave-aqui"\n'
+            'export AZURE_OPENAI_ENDPOINT="https://<recurso>.openai.azure.com/"\n'
+            'export OPENAI_API_VERSION="2025-03-01-preview"'
+        ),
+    },
+}
+
+
 def _infer_provider_info(provider: str) -> dict:
     """Infere informações do provider dinamicamente.
 
@@ -68,6 +117,9 @@ def _infer_provider_info(provider: str) -> dict:
     """
     if not provider:
         return {'package': None, 'install': None, 'env_var': 'API_KEY', 'name': 'LLM'}
+
+    if provider in _PROVIDER_OVERRIDES:
+        return dict(_PROVIDER_OVERRIDES[provider])
 
     # Inferir nome do pacote: provider -> langchain_{provider}
     package = f"langchain_{provider}"
@@ -270,6 +322,29 @@ def get_friendly_error_message(error: Exception, provider: str = None) -> str:
 
     # === ERROS DE AUTENTICAÇÃO ===
     if any(p in error_str for p in ['authenticationerror', 'invalidapikey', '401', 'api_key', 'api key']):
+        if env_var is None:
+            # Auth via credenciais de SDK (Vertex AI ADC, AWS creds, etc)
+            auth_hint = provider_data.get(
+                'auth_hint',
+                'Configure as credenciais conforme a documentação do provider.'
+            )
+            hint_lines = '\n'.join(f"║     {line}" for line in auth_hint.split('\n'))
+            msg = f"""
+╔══════════════════════════════════════════════════════════════════════════════╗
+║  ERRO DE AUTENTICAÇÃO - Credenciais não configuradas                         ║
+╠══════════════════════════════════════════════════════════════════════════════╣
+║                                                                              ║
+║  O {provider_name} usa credenciais de SDK (não uma API key tradicional).
+║                                                                              ║
+║  COMO RESOLVER:
+║
+{hint_lines}
+║                                                                              ║
+║  Verifique também se região, projeto/conta e modelo estão corretos.
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+"""
+            return msg.strip()
         msg = f"""
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  ERRO DE AUTENTICAÇÃO - Chave de API inválida ou não configurada             ║

--- a/src/dataframeit/errors.py
+++ b/src/dataframeit/errors.py
@@ -57,6 +57,19 @@ NON_RECOVERABLE_ERRORS = (
 )
 
 
+# Auth via credenciais de SDK (sem env var de API key) compartilhada por
+# todos os providers Bedrock. Linhas mantidas curtas para caber em caixas de 80 cols.
+_BEDROCK_BASE = {
+    'package': 'langchain_aws',
+    'install': 'langchain-aws',
+    'env_var': None,
+    'auth_hint': (
+        'aws configure\n'
+        'OU exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY\n'
+        '(opcional: AWS_SESSION_TOKEN, AWS_REGION)'
+    ),
+}
+
 # Providers cuja heurística simples (langchain_{provider} + {PROVIDER}_API_KEY) não bate com a realidade.
 # env_var=None indica auth por SDK (ADC, AWS creds), não por API key.
 _PROVIDER_OVERRIDES = {
@@ -70,28 +83,8 @@ _PROVIDER_OVERRIDES = {
             'OU exporte GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json'
         ),
     },
-    'bedrock': {
-        'package': 'langchain_aws',
-        'install': 'langchain-aws',
-        'env_var': None,
-        'name': 'AWS Bedrock',
-        'auth_hint': (
-            'aws configure\n'
-            'OU exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY '
-            '(opcional: AWS_SESSION_TOKEN, AWS_REGION)'
-        ),
-    },
-    'bedrock_converse': {
-        'package': 'langchain_aws',
-        'install': 'langchain-aws',
-        'env_var': None,
-        'name': 'AWS Bedrock (Converse)',
-        'auth_hint': (
-            'aws configure\n'
-            'OU exporte AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY '
-            '(opcional: AWS_SESSION_TOKEN, AWS_REGION)'
-        ),
-    },
+    'bedrock': {**_BEDROCK_BASE, 'name': 'AWS Bedrock'},
+    'bedrock_converse': {**_BEDROCK_BASE, 'name': 'AWS Bedrock (Converse)'},
     'azure_openai': {
         'package': 'langchain_openai',
         'install': 'langchain-openai',
@@ -323,46 +316,54 @@ def get_friendly_error_message(error: Exception, provider: str = None) -> str:
     # === ERROS DE AUTENTICAÇÃO ===
     if any(p in error_str for p in ['authenticationerror', 'invalidapikey', '401', 'api_key', 'api key']):
         if env_var is None:
-            # Auth via credenciais de SDK (Vertex AI ADC, AWS creds, etc)
+            # Auth via credenciais de SDK (Vertex AI ADC, AWS creds, etc).
             auth_hint = provider_data.get(
                 'auth_hint',
                 'Configure as credenciais conforme a documentação do provider.'
             )
-            hint_lines = '\n'.join(f"║     {line}" for line in auth_hint.split('\n'))
+            hint_lines = '\n'.join(
+                f"║     {line:<73}║" for line in auth_hint.split('\n')
+            )
             msg = f"""
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  ERRO DE AUTENTICAÇÃO - Credenciais não configuradas                         ║
 ╠══════════════════════════════════════════════════════════════════════════════╣
 ║                                                                              ║
-║  O {provider_name} usa credenciais de SDK (não uma API key tradicional).
+║  Provider: {provider_name:<66}║
 ║                                                                              ║
-║  COMO RESOLVER:
-║
+║  Este provider usa credenciais de SDK (não uma API key tradicional).         ║
+║                                                                              ║
+║  COMO RESOLVER:                                                              ║
+║                                                                              ║
 {hint_lines}
 ║                                                                              ║
-║  Verifique também se região, projeto/conta e modelo estão corretos.
+║  Verifique também se região, projeto/conta e modelo estão corretos.          ║
 ║                                                                              ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 """
             return msg.strip()
+        export_linux = f'export {env_var}="sua-chave-aqui"'
+        export_win = f'$env:{env_var}="sua-chave-aqui"'
         msg = f"""
 ╔══════════════════════════════════════════════════════════════════════════════╗
 ║  ERRO DE AUTENTICAÇÃO - Chave de API inválida ou não configurada             ║
 ╠══════════════════════════════════════════════════════════════════════════════╣
 ║                                                                              ║
-║  O {provider_name} não aceitou sua chave de API.                             ║
+║  Provider: {provider_name:<66}║
+║                                                                              ║
+║  Sua chave de API não foi aceita.                                            ║
 ║                                                                              ║
 ║  COMO RESOLVER:                                                              ║
 ║                                                                              ║
-║  1. Obtenha uma chave de API no site/console do {provider_name}              ║
+║  1. Obtenha uma chave de API no site/console do provider.                    ║
 ║                                                                              ║
-║  2. Configure a chave no terminal (antes de executar seu código):            ║
+║  2. Configure no terminal (antes de executar seu código):                    ║
 ║                                                                              ║
 ║     No Linux/Mac:                                                            ║
-║     export {env_var}="sua-chave-aqui"                                        ║
+║     {export_linux:<73}║
 ║                                                                              ║
 ║     No Windows (PowerShell):                                                 ║
-║     $env:{env_var}="sua-chave-aqui"                                          ║
+║     {export_win:<73}║
 ║                                                                              ║
 ║  3. OU passe diretamente no código:                                          ║
 ║     dataframeit(..., api_key="sua-chave-aqui")                               ║

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,106 @@
+"""Testes para inferência de provider em dataframeit.errors."""
+from dataframeit.errors import _infer_provider_info
+
+
+class TestInferProviderInfoOverrides:
+    """Overrides para providers cloud (Vertex AI, Bedrock, Azure OpenAI)."""
+
+    def test_google_vertexai(self):
+        info = _infer_provider_info('google_vertexai')
+        assert info['package'] == 'langchain_google_vertexai'
+        assert info['install'] == 'langchain-google-vertexai'
+        assert info['env_var'] is None
+        assert info['name'] == 'Google Vertex AI'
+        assert 'gcloud' in info['auth_hint']
+
+    def test_bedrock(self):
+        info = _infer_provider_info('bedrock')
+        assert info['package'] == 'langchain_aws'
+        assert info['install'] == 'langchain-aws'
+        assert info['env_var'] is None
+        assert info['name'] == 'AWS Bedrock'
+        assert 'aws' in info['auth_hint'].lower()
+
+    def test_bedrock_converse(self):
+        info = _infer_provider_info('bedrock_converse')
+        assert info['package'] == 'langchain_aws'
+        assert info['install'] == 'langchain-aws'
+        assert info['env_var'] is None
+        assert info['name'] == 'AWS Bedrock (Converse)'
+
+    def test_azure_openai(self):
+        info = _infer_provider_info('azure_openai')
+        assert info['package'] == 'langchain_openai'
+        assert info['install'] == 'langchain-openai'
+        assert info['env_var'] == 'AZURE_OPENAI_API_KEY'
+        assert info['name'] == 'Azure OpenAI'
+        assert 'AZURE_OPENAI_ENDPOINT' in info['auth_hint']
+
+
+class TestInferProviderInfoHeuristic:
+    """A heurística genérica continua valendo para providers sem override."""
+
+    def test_google_genai(self):
+        info = _infer_provider_info('google_genai')
+        assert info['package'] == 'langchain_google_genai'
+        assert info['install'] == 'langchain-google-genai'
+        assert info['env_var'] == 'GOOGLE_API_KEY'
+        assert info['name'] == 'Google Gemini'
+
+    def test_openai(self):
+        info = _infer_provider_info('openai')
+        assert info['package'] == 'langchain_openai'
+        assert info['env_var'] == 'OPENAI_API_KEY'
+
+    def test_anthropic(self):
+        info = _infer_provider_info('anthropic')
+        assert info['package'] == 'langchain_anthropic'
+        assert info['env_var'] == 'ANTHROPIC_API_KEY'
+
+    def test_unknown_provider_falls_back(self):
+        info = _infer_provider_info('foo_bar')
+        assert info['package'] == 'langchain_foo_bar'
+        assert info['install'] == 'langchain-foo-bar'
+        assert info['env_var'] == 'FOO_BAR_API_KEY'
+        assert info['name'] == 'Foo Bar'
+
+    def test_empty_provider(self):
+        info = _infer_provider_info('')
+        assert info['package'] is None
+        assert info['name'] == 'LLM'
+
+
+class TestFriendlyAuthErrorWithoutEnvVar:
+    """Mensagem de auth deve adaptar quando provider usa credenciais SDK."""
+
+    def test_vertexai_auth_error_uses_sdk_message(self):
+        from dataframeit.errors import get_friendly_error_message
+
+        msg = get_friendly_error_message(
+            Exception("AuthenticationError: invalid credentials"),
+            provider='google_vertexai',
+        )
+        assert 'Google Vertex AI' in msg
+        assert 'gcloud auth application-default login' in msg
+        # Não deve sugerir export de API key inexistente
+        assert 'GOOGLE_VERTEXAI_API_KEY' not in msg
+
+    def test_bedrock_auth_error_uses_sdk_message(self):
+        from dataframeit.errors import get_friendly_error_message
+
+        msg = get_friendly_error_message(
+            Exception("AuthenticationError: 401"),
+            provider='bedrock_converse',
+        )
+        assert 'aws configure' in msg.lower() or 'AWS_ACCESS_KEY_ID' in msg
+        assert 'BEDROCK_CONVERSE_API_KEY' not in msg
+
+    def test_openai_auth_error_keeps_api_key_message(self):
+        from dataframeit.errors import get_friendly_error_message
+
+        msg = get_friendly_error_message(
+            Exception("AuthenticationError: bad key"),
+            provider='openai',
+        )
+        assert 'OPENAI_API_KEY' in msg
+        assert 'export OPENAI_API_KEY' in msg


### PR DESCRIPTION
## Resumo

Fecha #102. Adiciona suporte de **documentação + mensagens de erro** para usar LLMs hospedados em regiões do Brasil (Vertex AI `southamerica-east1`, AWS Bedrock `sa-east-1`, Azure OpenAI Brazil South), e corrige a inferência de pacote/env var de `errors.py` para esses providers cloud.

## Mudanças

- **Docs**: receitas em `docs/guides/providers.md` (PT) e `docs/en/guides/providers.md` (EN) para os três providers em região BR.
- **`errors._infer_provider_info`**: overrides para `google_vertexai`, `bedrock`, `bedrock_converse` e `azure_openai` — pacote (`langchain-aws`, `langchain-google-vertexai`, `langchain-openai`), install name, env var (None para Vertex/Bedrock; `AZURE_OPENAI_API_KEY` para Azure) e auth_hint correto.
- **`errors.get_friendly_error_message`**: quando o provider não tem env var (Vertex/Bedrock), a mensagem orienta `gcloud auth application-default login` ou `aws configure` em vez de sugerir `export PROVIDER_API_KEY` inexistente.
- **Testes**: `tests/test_errors.py` cobre overrides, heurística genérica, e mensagens amigáveis com/sem env var.
- **Bump**: 0.7.0 → 0.7.1

## Test plan

- [x] `uv run pytest tests/test_errors.py` passa
- [x] Suite completa verde
- [ ] Validar localmente uma chamada com `provider="google_vertexai"` para conferir mensagem de erro real